### PR TITLE
Enable full toolpath tile menu features

### DIFF
--- a/gui/src/mainwindow.cpp
+++ b/gui/src/mainwindow.cpp
@@ -323,19 +323,9 @@ void MainWindow::setupConnections()
     if (m_toolpathTimeline && m_toolpathGenerationController) {
         m_toolpathGenerationController->connectTimelineWidget(m_toolpathTimeline);
         
-        // Connect toolpath generation controller signals to main window
-        connect(m_toolpathGenerationController, &IntuiCAM::GUI::ToolpathGenerationController::toolpathAdded,
-                this, [this](const QString& name, const QString& type, const QString& toolName) {
-                    // Add the toolpath to the timeline
-                    m_toolpathTimeline->addToolpath(name, type, toolName, QString());
-                    
-                    // Log to output window
-                    logToOutput(QString("Added %1 toolpath: %2 with tool: %3").arg(type, name, toolName));
-                });
-        
-        // IMPORTANT: The following connections will result in the same operations being performed twice
-        // because the ToolpathGenerationController already connects to these signals.
-        // We will keep connections that the controller doesn't handle, but remove duplicate handlers.
+        // The controller will directly update the timeline when toolpaths are
+        // added or removed. Only connect signals that the controller does not
+        // handle itself.
         
         // Connect to toolpath selected signal (not handled by controller)
         connect(m_toolpathTimeline, &ToolpathTimelineWidget::toolpathSelected,

--- a/gui/src/toolpathgenerationcontroller.cpp
+++ b/gui/src/toolpathgenerationcontroller.cpp
@@ -1125,14 +1125,33 @@ void IntuiCAM::GUI::ToolpathGenerationController::connectTimelineWidget(Toolpath
                 dialog->setAttribute(Qt::WA_DeleteOnClose);
             });
     
+
     // Connect toolpath regeneration signal
     connect(timelineWidget, &ToolpathTimelineWidget::toolpathRegenerateRequested,
             this, [this, timelineWidget](int index) {
                 QString name = timelineWidget->getToolpathName(index);
                 QString type = timelineWidget->getToolpathType(index);
-                
+
                 // Regenerate the toolpath
                 regenerateToolpath(name, type);
+            });
+
+    // --- Connect controller signals back to the timeline --------------------
+    connect(this, &ToolpathGenerationController::toolpathAdded,
+            timelineWidget,
+            [timelineWidget](const QString& name, const QString& type, const QString& toolName) {
+                timelineWidget->addToolpath(name, type, toolName);
+            });
+
+    connect(this, &ToolpathGenerationController::toolpathRemoved,
+            timelineWidget,
+            [timelineWidget](const QString& name) {
+                for (int i = 0; i < timelineWidget->getToolpathCount(); ++i) {
+                    if (timelineWidget->getToolpathName(i) == name) {
+                        timelineWidget->removeToolpath(i);
+                        break;
+                    }
+                }
             });
 }
 


### PR DESCRIPTION
## Summary
- connect toolpath generation controller with timeline widget
- simplify main window setup so only the controller manages timeline updates

## Testing
- `ctest --output-on-failure -j2` *(fails: No tests were found)*

------
https://chatgpt.com/codex/tasks/task_e_684b223c38d88332bc2c21b832aff5a9