### PR TITLE
Add visibility menu overlay

### DIFF
--- a/gui/include/chuckmanager.h
+++ b/gui/include/chuckmanager.h
@@ -91,6 +91,16 @@ public:
      */
     void redisplayChuck();
 
+    /**
+     * @brief Show or hide the chuck without deleting it
+     */
+    void setChuckVisible(bool visible);
+
+    /**
+     * @brief Check if chuck is currently visible
+     */
+    bool isChuckVisible() const;
+
 signals:
     /**
      * @brief Emitted when chuck is successfully loaded

--- a/gui/include/mainwindow.h
+++ b/gui/include/mainwindow.h
@@ -15,7 +15,8 @@
 #include <QApplication>
 #include <QTabWidget>
 #include <QPushButton>
-#include <QCheckBox>
+#include <QToolButton>
+#include <QMenu>
 
 // OpenCASCADE includes
 #include <gp_Ax1.hxx>
@@ -136,6 +137,9 @@ private slots:
 
     // Overlay control for chuck visibility
     void handleShowChuckToggled(bool checked);
+    void handleShowRawMaterialToggled(bool checked);
+    void handleShowToolpathsToggled(bool checked);
+    void handleShowPartToggled(bool checked);
 
 private:
     void createMenus();
@@ -221,7 +225,12 @@ private:
     
     // Overlay UI elements
     QPushButton *m_viewModeOverlayButton;
-    QCheckBox *m_showChuckCheckBox;  // Overlay checkbox to show/hide chuck
+    QToolButton *m_visibilityButton;
+    QMenu *m_visibilityMenu;
+    QAction *m_showChuckAction;
+    QAction *m_showRawMaterialAction;
+    QAction *m_showToolpathsAction;
+    QAction *m_showPartAction;
     QString m_defaultChuckFilePath;  // Default path to chuck STEP file
     
 private:

--- a/gui/include/rawmaterialmanager.h
+++ b/gui/include/rawmaterialmanager.h
@@ -98,6 +98,11 @@ public:
     bool isRawMaterialDisplayed() const { return !m_rawMaterialAIS.IsNull(); }
 
     /**
+     * @brief Check if raw material is currently visible
+     */
+    bool isRawMaterialVisible() const;
+
+    /**
      * @brief Get the current raw material diameter
      * @return Current diameter in mm, or 0.0 if no raw material is displayed
      */
@@ -114,6 +119,11 @@ public:
      * Deactivates all selection modes for the raw material while keeping it visible
      */
     void makeRawMaterialNonSelectable();
+
+    /**
+     * @brief Show or hide the raw material without deleting it
+     */
+    void setRawMaterialVisible(bool visible);
 
     /**
      * @brief Set the facing allowance (extra material length in +Z direction)

--- a/gui/include/toolpathmanager.h
+++ b/gui/include/toolpathmanager.h
@@ -114,6 +114,16 @@ public:
     void setToolpathVisible(const QString& name, bool visible);
 
     /**
+     * @brief Show or hide all toolpaths
+     */
+    void setAllToolpathsVisible(bool visible);
+
+    /**
+     * @brief Check if any toolpaths are currently visible
+     */
+    bool areToolpathsVisible() const;
+
+    /**
      * @brief Set display settings for toolpaths
      */
     void setDisplaySettings(const ToolpathDisplaySettings& settings);

--- a/gui/include/workpiecemanager.h
+++ b/gui/include/workpiecemanager.h
@@ -96,6 +96,11 @@ public:
     void clearWorkpieces();
 
     /**
+     * @brief Show or hide all workpieces without deleting them
+     */
+    void setWorkpiecesVisible(bool visible);
+
+    /**
      * @brief Get all current workpieces
      */
     QVector<Handle(AIS_Shape)> getWorkpieces() const { return m_workpieces; }
@@ -105,6 +110,11 @@ public:
      * @return True if at least one workpiece is loaded
      */
     bool hasWorkpiece() const { return !m_workpieces.isEmpty(); }
+
+    /**
+     * @brief Check if workpieces are currently visible
+     */
+    bool areWorkpiecesVisible() const;
 
     /**
      * @brief Get the shape of the current workpiece

--- a/gui/src/chuckmanager.cpp
+++ b/gui/src/chuckmanager.cpp
@@ -298,4 +298,26 @@ void ChuckManager::redisplayChuck()
     catch (const std::exception& e) {
         qDebug() << "ChuckManager: Error redisplaying chuck:" << e.what();
     }
-} 
+}
+
+void ChuckManager::setChuckVisible(bool visible)
+{
+    if (m_context.IsNull() || m_chuckAIS.IsNull()) {
+        return;
+    }
+
+    if (visible) {
+        if (!m_context->IsDisplayed(m_chuckAIS)) {
+            m_context->Display(m_chuckAIS, Standard_False);
+        }
+    } else {
+        m_context->Erase(m_chuckAIS, Standard_False);
+    }
+
+    m_context->UpdateCurrentViewer();
+}
+
+bool ChuckManager::isChuckVisible() const
+{
+    return !m_context.IsNull() && !m_chuckAIS.IsNull() && m_context->IsDisplayed(m_chuckAIS);
+}

--- a/gui/src/mainwindow.cpp
+++ b/gui/src/mainwindow.cpp
@@ -42,7 +42,7 @@
 #include <QFrame>
 #include <QFileInfo>
 #include <QMessageBox>
-#include <QCheckBox>
+#include <QToolButton>
 
 // OpenCASCADE includes for gp_Ax1
 #include <gp_Ax1.hxx>
@@ -92,7 +92,12 @@ MainWindow::MainWindow(QWidget *parent)
     , m_preferencesAction(nullptr)
     , m_toggleViewModeAction(nullptr)
     , m_viewModeOverlayButton(nullptr)
-    , m_showChuckCheckBox(nullptr)
+    , m_visibilityButton(nullptr)
+    , m_visibilityMenu(nullptr)
+    , m_showChuckAction(nullptr)
+    , m_showRawMaterialAction(nullptr)
+    , m_showToolpathsAction(nullptr)
+    , m_showPartAction(nullptr)
     , m_defaultChuckFilePath("C:/Users/nikla/Downloads/three_jaw_chuck.step")
 {
     // Create business logic components
@@ -1206,12 +1211,28 @@ void MainWindow::createViewModeOverlayButton()
     m_viewModeOverlayButton = new QPushButton("Switch to Lathe View", this);
     m_viewModeOverlayButton->setMaximumWidth(150);
     m_viewModeOverlayButton->setMaximumHeight(30);
-    
-    // Create the checkbox to toggle chuck visibility
-    m_showChuckCheckBox = new QCheckBox("Show Chuck", this);
-    m_showChuckCheckBox->setChecked(true);
-    m_showChuckCheckBox->setMaximumHeight(30);
-    
+
+    // Create visibility tool button with menu
+    m_visibilityButton = new QToolButton(this);
+    m_visibilityButton->setText("Visibility");
+    m_visibilityButton->setPopupMode(QToolButton::InstantPopup);
+    m_visibilityButton->setMaximumHeight(30);
+
+    m_visibilityMenu = new QMenu(m_visibilityButton);
+    m_showChuckAction = m_visibilityMenu->addAction("Show Chuck");
+    m_showChuckAction->setCheckable(true);
+    m_showChuckAction->setChecked(true);
+    m_showRawMaterialAction = m_visibilityMenu->addAction("Show Raw Material");
+    m_showRawMaterialAction->setCheckable(true);
+    m_showRawMaterialAction->setChecked(true);
+    m_showToolpathsAction = m_visibilityMenu->addAction("Show Toolpaths");
+    m_showToolpathsAction->setCheckable(true);
+    m_showToolpathsAction->setChecked(true);
+    m_showPartAction = m_visibilityMenu->addAction("Show Part");
+    m_showPartAction->setCheckable(true);
+    m_showPartAction->setChecked(true);
+    m_visibilityButton->setMenu(m_visibilityMenu);
+
     // Style the button to be semi-transparent and visually appealing
     m_viewModeOverlayButton->setStyleSheet(
         "QPushButton {"
@@ -1233,10 +1254,10 @@ void MainWindow::createViewModeOverlayButton()
         "  border: 2px solid #555555;"
         "}"
     );
-    
-    // Style the checkbox similarly (background only, keep default indicator)
-    m_showChuckCheckBox->setStyleSheet(
-        "QCheckBox {"
+
+    // Style the visibility button similarly
+    m_visibilityButton->setStyleSheet(
+        "QToolButton {"
         "  background-color: rgba(240, 240, 240, 220);"
         "  border: 2px solid #666666;"
         "  border-radius: 6px;"
@@ -1245,31 +1266,34 @@ void MainWindow::createViewModeOverlayButton()
         "  font-weight: bold;"
         "  color: #333333;"
         "}"
-        "QCheckBox:hover {"
+        "QToolButton:hover {"
         "  background-color: rgba(255, 255, 255, 240);"
         "  border: 2px solid #444444;"
         "  color: #222222;"
         "}"
     );
-    
+
     // Connect the button to the toggle function
     connect(m_viewModeOverlayButton, &QPushButton::clicked, this, &MainWindow::toggleViewMode);
-    
-    // Connect checkbox toggled signal
-    connect(m_showChuckCheckBox, &QCheckBox::toggled, this, &MainWindow::handleShowChuckToggled);
-    
+
+    // Connect visibility actions
+    connect(m_showChuckAction, &QAction::toggled, this, &MainWindow::handleShowChuckToggled);
+    connect(m_showRawMaterialAction, &QAction::toggled, this, &MainWindow::handleShowRawMaterialToggled);
+    connect(m_showToolpathsAction, &QAction::toggled, this, &MainWindow::handleShowToolpathsToggled);
+    connect(m_showPartAction, &QAction::toggled, this, &MainWindow::handleShowPartToggled);
+
     // Connect to view mode changes to update button text
     connect(m_3dViewer, &OpenGL3DWidget::viewModeChanged, this, &MainWindow::updateViewModeOverlayButton);
-    
+
     // Initially position the button
     positionViewModeOverlayButton();
-    
+
     // Show the controls - they will always be visible on the setup tab
     m_viewModeOverlayButton->show();
     m_viewModeOverlayButton->raise();
-    m_showChuckCheckBox->show();
-    m_showChuckCheckBox->raise();
-    
+    m_visibilityButton->show();
+    m_visibilityButton->raise();
+
     qDebug() << "View mode overlay button created in MainWindow";
 }
 
@@ -1290,6 +1314,7 @@ void MainWindow::updateViewModeOverlayButton()
     // Ensure button stays positioned correctly and on top
     positionViewModeOverlayButton();
     m_viewModeOverlayButton->raise();
+    if (m_visibilityButton) m_visibilityButton->raise();
 }
 
 void MainWindow::positionViewModeOverlayButton()
@@ -1302,12 +1327,12 @@ void MainWindow::positionViewModeOverlayButton()
     bool onSetupTab = (m_tabWidget && m_tabWidget->currentIndex() == 1);
     if (!onSetupTab) {
         m_viewModeOverlayButton->hide();
-        if (m_showChuckCheckBox) m_showChuckCheckBox->hide();
+        if (m_visibilityButton) m_visibilityButton->hide();
         return;
     }
 
     m_viewModeOverlayButton->show();
-    if (m_showChuckCheckBox) m_showChuckCheckBox->show();
+    if (m_visibilityButton) m_visibilityButton->show();
 
     // Calculate position relative to the 3D viewer widget
     QPoint viewerGlobalPos = m_3dViewer->mapToGlobal(QPoint(0, 0));
@@ -1330,17 +1355,13 @@ void MainWindow::positionViewModeOverlayButton()
     m_viewModeOverlayButton->move(x, y);
     m_viewModeOverlayButton->raise();
 
-    // Position checkbox to the left of the button
-    if (m_showChuckCheckBox) {
-        int checkWidth = m_showChuckCheckBox->sizeHint().width();
-        int checkHeight = m_showChuckCheckBox->sizeHint().height();
-
-        int xCheck = x - checkWidth - spacing;
-        int yCheck = y + (buttonHeight - checkHeight) / 2;
-
-        xCheck = qMax(margin, xCheck);
-        m_showChuckCheckBox->move(xCheck, yCheck);
-        m_showChuckCheckBox->raise();
+    // Position visibility button to the left of the view mode button
+    if (m_visibilityButton) {
+        int visWidth = m_visibilityButton->sizeHint().width();
+        int xVis = x - visWidth - spacing;
+        xVis = qMax(margin, xVis);
+        m_visibilityButton->move(xVis, y);
+        m_visibilityButton->raise();
     }
 }
 
@@ -2108,22 +2129,75 @@ void MainWindow::handleShowChuckToggled(bool checked)
     }
 
     if (checked) {
-        // If chuck is already loaded, just redisplay it; otherwise, initialize
         if (chuckMgr->isChuckLoaded()) {
-            chuckMgr->redisplayChuck();
+            chuckMgr->setChuckVisible(true);
             statusBar()->showMessage(tr("Chuck displayed"), 2000);
         } else {
             bool success = m_workspaceController->initializeChuck(m_defaultChuckFilePath);
             statusBar()->showMessage(success ? tr("Chuck loaded and displayed") : tr("Failed to load chuck"), 3000);
+            if (!success) {
+                m_showChuckAction->setChecked(false);
+            }
         }
     } else {
-        // Hide chuck from view
-        chuckMgr->clearChuck();
+        chuckMgr->setChuckVisible(false);
         statusBar()->showMessage(tr("Chuck hidden"), 2000);
     }
 
     // Log action
     if (m_outputWindow) {
         m_outputWindow->append(QString("Chuck visibility toggled: %1").arg(checked ? "Visible" : "Hidden"));
+    }
+}
+
+void MainWindow::handleShowRawMaterialToggled(bool checked)
+{
+    if (!m_workspaceController) {
+        return;
+    }
+
+    RawMaterialManager* rm = m_workspaceController->getRawMaterialManager();
+    if (!rm) {
+        return;
+    }
+
+    if (checked) {
+        rm->setRawMaterialVisible(true);
+        statusBar()->showMessage(tr("Raw material displayed"), 2000);
+    } else {
+        rm->setRawMaterialVisible(false);
+        statusBar()->showMessage(tr("Raw material hidden"), 2000);
+    }
+
+    if (m_outputWindow) {
+        m_outputWindow->append(QString("Raw material visibility toggled: %1").arg(checked ? "Visible" : "Hidden"));
+    }
+}
+
+void MainWindow::handleShowToolpathsToggled(bool checked)
+{
+    if (!m_toolpathManager) {
+        return;
+    }
+
+    m_toolpathManager->setAllToolpathsVisible(checked);
+    statusBar()->showMessage(checked ? tr("Toolpaths displayed") : tr("Toolpaths hidden"), 2000);
+
+    if (m_outputWindow) {
+        m_outputWindow->append(QString("Toolpath visibility toggled: %1").arg(checked ? "Visible" : "Hidden"));
+    }
+}
+
+void MainWindow::handleShowPartToggled(bool checked)
+{
+    if (!m_workpieceManager) {
+        return;
+    }
+
+    m_workpieceManager->setWorkpiecesVisible(checked);
+    statusBar()->showMessage(checked ? tr("Part displayed") : tr("Part hidden"), 2000);
+
+    if (m_outputWindow) {
+        m_outputWindow->append(QString("Part visibility toggled: %1").arg(checked ? "Visible" : "Hidden"));
     }
 }

--- a/gui/src/rawmaterialmanager.cpp
+++ b/gui/src/rawmaterialmanager.cpp
@@ -171,6 +171,28 @@ void RawMaterialManager::setRawMaterialTransparency(double transparency)
     }
 }
 
+void RawMaterialManager::setRawMaterialVisible(bool visible)
+{
+    if (m_context.IsNull() || m_rawMaterialAIS.IsNull()) {
+        return;
+    }
+
+    if (visible) {
+        if (!m_context->IsDisplayed(m_rawMaterialAIS)) {
+            m_context->Display(m_rawMaterialAIS, Standard_False);
+        }
+    } else {
+        m_context->Erase(m_rawMaterialAIS, Standard_False);
+    }
+
+    m_context->UpdateCurrentViewer();
+}
+
+bool RawMaterialManager::isRawMaterialVisible() const
+{
+    return !m_context.IsNull() && !m_rawMaterialAIS.IsNull() && m_context->IsDisplayed(m_rawMaterialAIS);
+}
+
 TopoDS_Shape RawMaterialManager::createCylinder(double diameter, double length, const gp_Ax1& axis)
 {
     try {

--- a/gui/src/toolpathmanager.cpp
+++ b/gui/src/toolpathmanager.cpp
@@ -211,6 +211,44 @@ void ToolpathManager::setToolpathVisible(const QString& name, bool visible)
     }
 }
 
+void ToolpathManager::setAllToolpathsVisible(bool visible)
+{
+    if (m_context.IsNull()) {
+        return;
+    }
+
+    for (auto it = m_displayedToolpaths.begin(); it != m_displayedToolpaths.end(); ++it) {
+        Handle(AIS_Shape) toolpathAIS = it.value();
+        if (!toolpathAIS.IsNull()) {
+            if (visible) {
+                if (!m_context->IsDisplayed(toolpathAIS)) {
+                    m_context->Display(toolpathAIS, Standard_False);
+                }
+            } else {
+                m_context->Erase(toolpathAIS, Standard_False);
+            }
+        }
+    }
+
+    m_context->UpdateCurrentViewer();
+}
+
+bool ToolpathManager::areToolpathsVisible() const
+{
+    if (m_context.IsNull()) {
+        return false;
+    }
+
+    for (auto it = m_displayedToolpaths.constBegin(); it != m_displayedToolpaths.constEnd(); ++it) {
+        Handle(AIS_Shape) ais = it.value();
+        if (!ais.IsNull() && m_context->IsDisplayed(ais)) {
+            return true;
+        }
+    }
+
+    return false;
+}
+
 void ToolpathManager::setDisplaySettings(const ToolpathDisplaySettings& settings)
 {
     m_displaySettings = settings;

--- a/gui/src/workpiecemanager.cpp
+++ b/gui/src/workpiecemanager.cpp
@@ -328,8 +328,44 @@ void WorkpieceManager::clearWorkpieces()
     // Reset axis alignment state
     m_hasAxisAlignment = false;
     m_axisAlignmentTransform = gp_Trsf(); // Reset to identity
-    
+
     qDebug() << "All workpieces cleared";
+}
+
+void WorkpieceManager::setWorkpiecesVisible(bool visible)
+{
+    if (m_context.IsNull()) {
+        return;
+    }
+
+    for (Handle(AIS_Shape) workpiece : m_workpieces) {
+        if (!workpiece.IsNull()) {
+            if (visible) {
+                if (!m_context->IsDisplayed(workpiece)) {
+                    m_context->Display(workpiece, Standard_False);
+                }
+            } else {
+                m_context->Erase(workpiece, Standard_False);
+            }
+        }
+    }
+
+    m_context->UpdateCurrentViewer();
+}
+
+bool WorkpieceManager::areWorkpiecesVisible() const
+{
+    if (m_context.IsNull()) {
+        return false;
+    }
+
+    for (Handle(AIS_Shape) workpiece : m_workpieces) {
+        if (!workpiece.IsNull() && m_context->IsDisplayed(workpiece)) {
+            return true;
+        }
+    }
+
+    return false;
 }
 
 void WorkpieceManager::setWorkpieceMaterial(Handle(AIS_Shape) workpieceAIS)


### PR DESCRIPTION
## Summary
- replace Show Chuck checkbox with dropdown Visibility menu
- allow toggling chuck, raw material, toolpaths and part visibility
- implement manager helpers for showing/hiding objects

## Testing
- `cmake -S . -B build` *(fails: Could not find a package configuration file provided by "Qt6")*

------
https://chatgpt.com/codex/tasks/task_e_684b21f357988332b564ac4a58ae9ff1