### PR TITLE
Update docs for simplified toolpath workflow

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -79,7 +79,7 @@ IntuiCAM/                   # Root of the repo
 * **Modular Architecture**:
   * **`common`**: Shared data structures, utilities, and interfaces
   * **`geometry`**: STEP import and B-Rep handling (via OpenCASCADE)
-  * **`toolpath`**: Lathe operations algorithms (Facing, Roughing, Finishing, Parting)
+  * **`toolpath`**: Lathe operation algorithms (Contouring, Threading, Chamfering, Parting)
   * **`postprocessor`**: G-code generation and machine-specific adaptations
   * **`simulation`**: Material removal simulation
 * **Design**:

--- a/docs/core/core_design.md
+++ b/docs/core/core_design.md
@@ -1,19 +1,12 @@
 # Details regarding the CAM-Core-Engine
 ## Turning Toolpath Generation
-**The following turning toolpaths are proposed:**
-* Outside roughing
-* Outside finishing
-* Inside roughing
-* Inside finishing
-* Drilling
-* Facing
-* Parting
-* Threading
-* Outside grooving
-* Inside grooving
-* Chamfering
-* (Trepaning - Grooving on the face of the part)
-* (Adaptive Roughing)
+**Default turning toolpaths**
+1. **Contouring** – combines facing, roughing and finishing passes.
+2. **Threading** – configurable pitch and face selection.
+3. **Chamfering** – configurable edge selection and size.
+4. **Parting** – defines how the part is cut off.
+
+Additional specialized operations such as grooving or drilling may be added in the future.
 
 All turning need to support cam-side cutter radius compensation. This can also be done on the machine-side therefore it must be toggleable.
 

--- a/docs/getting_started.md
+++ b/docs/getting_started.md
@@ -44,6 +44,8 @@ cd build
 
 🚧 **Note**: IntuiCAM is currently in active development. The user interface and workflows are being implemented.
 
+When you load a STEP file, IntuiCAM automatically creates four machining steps—Contouring, Threading, Chamfering and Parting. These appear in the toolpath timeline at the bottom of the window, where you can enable or disable each step.
+
 ### Current Status
 
 - ✅ **Build System**: Complete and verified

--- a/docs/gui/auto_apply_changes.md
+++ b/docs/gui/auto_apply_changes.md
@@ -1,8 +1,8 @@
-# Auto-Apply Changes in Part Loading Panel
+# Auto-Apply Changes in the Setup Panel
 
 ## Overview
 
-The part loading panel now features automatic application of changes to the 3D viewer. When you modify any setting in the panel, the changes are immediately reflected in the 3D workspace without requiring manual application.
+The setup panel features automatic application of changes to the 3D viewer. When you modify any setting, the result is immediately reflected without requiring manual application.
 
 ## Features
 
@@ -42,7 +42,7 @@ bool applyPartLoadingSettings(double distance, double diameter, bool flipped, in
 
 ### Signal Flow
 
-1. **User changes setting** in part loading panel
+1. **User changes setting** in the setup panel
 2. **Panel emits signal** with new value
 3. **MainWindow handler** receives signal
 4. **WorkspaceController method** applies change

--- a/docs/gui/gui_design.md
+++ b/docs/gui/gui_design.md
@@ -5,29 +5,19 @@
 - Allows for selection of rotary
 - Workpiece is shown inside of raw material is shown held by the chuck
 
-### Manual Path Generation
-- User can manually select which feature to turn where
-- The following toolpaths are proposed:
-  - Outside roughing
-  - Outside finishing
-  - Inside roughing
-  - Inside finishing
-  - Drilling
-  - Facing
-  - Parting
-  - Threading
-  - (Trepaning - Turning on the face of the part)
-  - (Adaptive Roughing)
-- The toolpath selection should be stored in a list where the order of the list corresponds to the order of machining operations
-- When a toolpath is first set up or selected in the list, a menu opens where the user can adjust parameters
+### Automatic Toolpath Timeline
+After a STEP file is loaded, IntuiCAM automatically creates a fixed sequence of machining steps. These steps appear at the bottom of the window in the **toolpath timeline**. Each step can be toggled on or off and edited individually.
 
-  ### Atomatic Toolpath Generation
-  The User can click a button and the following steps are automated.
-  - The standard order of operations is automatically added to the toolpath list <br>
+The standard steps are:
+1. **Contouring** – performs facing, roughing and finishing in one operation.
+2. **Threading** – user selects faces and pitch.
+3. **Chamfering** – user selects edges and chamfer size.
+4. **Parting** – defines part‑off strategy.
 
-    Facing &rarr; Drilling &rarr; Internal Roughing &rarr; Internal Finishing &rarr; External Roughing &rarr; External Finishing &rarr; Parting <br>
+Users may adjust parameters or disable steps directly from the timeline tabs.
 
-    (If the part doesnt have internal features for example, the corresponding steps will be skipped)
+### Automatic Generation
+Toolpaths are created as soon as a STEP file is loaded. The timeline always starts with Contouring followed by Threading, Chamfering and Parting. Users simply review the steps and disable or modify them as needed.
 
   ### Simulation
   A simulation combinded with collision detection will be automatically invoked (Similiar to 3D-Printing Slicers)

--- a/docs/gui/setup_tab_restructuring_plan.md
+++ b/docs/gui/setup_tab_restructuring_plan.md
@@ -32,7 +32,7 @@ Restructure the setup tab layout based on Orca Slicer/Bambu Studio's intuitive d
    - **Part Setup**: STEP file loading, axis selection, positioning
    - **Material Settings**: Raw material diameter, material type selection, surface finish requirements
    - **Machining Parameters**: Facing allowance, stock allowance, safety margins
-   - **Operations Control**: Individual operation toggles (facing, roughing, finishing, parting)
+   - **Operations Control**: Individual toggles for Contouring, Threading, Chamfering and Parting
    - **Quality Settings**: Surface finish specifications, precision levels
 
 3. **Add Operation Controls**
@@ -185,7 +185,7 @@ Restructure the setup tab layout based on Orca Slicer/Bambu Studio's intuitive d
   - ✅ Implemented Part Setup group (STEP loading, axis selection, positioning)
   - ✅ Implemented Material Settings group (material type, raw dimensions, properties)
   - ✅ Implemented Machining Parameters group (allowances, safety margins)
-  - ✅ Implemented Operations Control group (enable/disable operations, parameters access)
+  - ✅ Implemented Operations Control group (toggle Contouring, Threading, Chamfering and Parting)
   - ✅ Implemented Quality Settings group (surface finish, tolerance)
   - ✅ Implemented Automatic Generation Controls (prominent button, progress tracking)
   - ✅ Added modern styling inspired by Orca Slicer with color-coded sections

--- a/docs/index.md
+++ b/docs/index.md
@@ -12,8 +12,10 @@ Whether you’re a user looking to generate your first turning job or a develope
 - [Windows Setup Guide](windows_setup.md)  
   Comprehensive Windows-specific setup guide with tested configuration and troubleshooting.
 
-- [Getting Started](getting_started.md)  
+- [Getting Started](getting_started.md)
   Quick tutorial to import a model, define your setup, and generate your first toolpaths.
+- [Updated Toolpath Workflow](toolpath_workflow.md)
+  Overview of the simplified operation sequence and timeline interface.
 
 - [Chuck Management User Guide](user_guide_chuck.md)  
   Complete guide to using the 3-jaw chuck management and workpiece alignment features.

--- a/docs/toolpath_workflow.md
+++ b/docs/toolpath_workflow.md
@@ -1,0 +1,24 @@
+# Updated Toolpath Workflow
+
+This document summarizes the simplified toolpath generation workflow introduced in IntuiCAM.
+
+## Automatic Step Creation
+
+When a STEP file is loaded, the application automatically creates a set of machining steps. These steps are displayed in order at the bottom of the window in the **toolpath timeline**:
+
+1. **Contouring** – automatically performs facing, roughing and finishing of the entire part.
+2. **Threading** – lets you choose the faces to be threaded and define the pitch.
+3. **Chamfering** – lets you select edges to chamfer and specify the chamfer size.
+4. **Parting** – allows you to define how the part should be parted off.
+
+All steps are generated for every uploaded part. You can enable or disable each step individually in the timeline.
+
+## Revised Setup Tab Layout
+
+The left side of the setup tab has been simplified:
+
+- The previous tab widget with *Part Setup* and *Machining* tabs has been removed.
+- The **upper half** now contains the part setup controls. Here you upload the STEP file, set the orientation and choose the material type and starting diameter.
+- The **lower half** contains a new tab view with one tab for each machining step (Contouring, Threading, Chamfering, Parting). Each tab lets you choose tools and adjust parameters relevant to that step.
+
+These settings are dedicated to lathe turning and are independent for every step.  The timeline at the bottom always shows the steps in the same order, but you can deactivate any of them.


### PR DESCRIPTION
## Summary
- document new automatic toolpath workflow
- describe updated setup tab layout and timeline behaviour
- update architecture and core design docs for new operations
- adjust GUI documentation and auto-apply guide
- mention workflow in Getting Started and index

## Testing
- `ctest --output-on-failure`

------
https://chatgpt.com/codex/tasks/task_e_684b27e101e083329899015534fc9f3e