### PR TITLE
Revise documentation for new toolpath workflow

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -79,7 +79,7 @@ IntuiCAM/                   # Root of the repo
 * **Modular Architecture**:
   * **`common`**: Shared data structures, utilities, and interfaces
   * **`geometry`**: STEP import and B-Rep handling (via OpenCASCADE)
-  * **`toolpath`**: Lathe operations algorithms (Facing, Roughing, Finishing, Parting)
+  * **`toolpath`**: Lathe operations algorithms (Contouring, Threading, Chamfering, Parting)
   * **`postprocessor`**: G-code generation and machine-specific adaptations
   * **`simulation`**: Material removal simulation
 * **Design**:
@@ -274,7 +274,7 @@ The workspace management system exemplifies the application's modular architectu
 
 1. **Import**: User loads a STEP file → Core geometry module parses into B-Rep model.
 2. **Setup**: User defines rotation axis, stock, and chuck in GUI → WorkspaceController coordinates setup.
-3. **Tool & Operation**: GUI or script configures tools and operations → WorkspaceController validates and manages workflow.
+3. **Operations**: The GUI automatically creates a timeline of Contouring, Threading, Chamfering, and Parting steps which can be toggled before computation.
 4. **Compute**: GUI calls WorkspaceController methods → Core computes and stores toolpaths.
 5. **Preview**: GUI queries managers through WorkspaceController → 3D viewport renders model + toolpaths.
 6. **Export**: GUI or CLI invokes postprocessor → G-Code is formatted and written to file.

--- a/docs/core/core_design.md
+++ b/docs/core/core_design.md
@@ -1,29 +1,16 @@
-# Details regarding the CAM-Core-Engine
-## Turning Toolpath Generation
-**The following turning toolpaths are proposed:**
-* Outside roughing
-* Outside finishing
-* Inside roughing
-* Inside finishing
-* Drilling
-* Facing
-* Parting
-* Threading
-* Outside grooving
-* Inside grooving
-* Chamfering
-* (Trepaning - Grooving on the face of the part)
-* (Adaptive Roughing)
+# CAM Core Engine Overview
 
-All turning need to support cam-side cutter radius compensation. This can also be done on the machine-side therefore it must be toggleable.
+## Automatic Turning Workflow
+IntuiCAM's initial focus is CNC turning. The core automatically creates four default steps when a new job is generated:
 
-## Milling Toolpath Generation
-**The following milling toolpaths are proposed:**
-* Basic Linear Roughing
-* Adaptive Roughing
-* Contouring
-* Drilling
-* Chamfer Milling
-* Radius Milling
-* (Thread Milling)
+1. **Contouring**
+2. **Threading**
+3. **Chamfering**
+4. **Parting**
 
+These steps appear in the GUI as a timeline. Each can be toggled on or off before toolpath computation. Support for additional operations such as roughing and drilling is planned for future versions.
+
+All turning operations support cutter radius compensation. It can be applied on the CAM side or delegated to the machine controller.
+
+## Future Milling Capabilities
+Milling toolpaths are not yet implemented but the architecture allows for future extensions (e.g. adaptive roughing, contour milling, drilling).

--- a/docs/getting_started.md
+++ b/docs/getting_started.md
@@ -43,6 +43,16 @@ cd build
 ## First Steps
 
 🚧 **Note**: IntuiCAM is currently in active development. The user interface and workflows are being implemented.
+### Part Setup and Default Steps
+When you import a model, IntuiCAM opens the **Part Setup** tab. The top portion contains orientation and chuck settings. Below that, a timeline displays four predefined machining steps:
+
+1. **Contouring**
+2. **Threading**
+3. **Chamfering**
+4. **Parting**
+
+These steps are created automatically and can be toggled on or off before you generate the toolpath.
+
 
 ### Current Status
 
@@ -52,7 +62,7 @@ cd build
 - 🔄 **GUI Implementation**: In progress
 - 🔄 **CAM Algorithms**: In development
 - 🔄 **STEP Import**: Planned
-- 🔄 **Toolpath Generation**: Planned
+- ✅ **Toolpath Generation**: Automatic default steps implemented
 - 🔄 **G-Code Export**: Planned
 
 ### Development Roadmap

--- a/docs/gui/gui_design.md
+++ b/docs/gui/gui_design.md
@@ -1,40 +1,17 @@
-# Details regarding the GUI-Component 
-## Proposed Features (Turning)
-### Step Viewer
-- Allows for selection of to be turned or to be skipped surfaces
-- Allows for selection of rotary
-- Workpiece is shown inside of raw material is shown held by the chuck
+# GUI Overview
 
-### Manual Path Generation
-- User can manually select which feature to turn where
-- The following toolpaths are proposed:
-  - Outside roughing
-  - Outside finishing
-  - Inside roughing
-  - Inside finishing
-  - Drilling
-  - Facing
-  - Parting
-  - Threading
-  - (Trepaning - Turning on the face of the part)
-  - (Adaptive Roughing)
-- The toolpath selection should be stored in a list where the order of the list corresponds to the order of machining operations
-- When a toolpath is first set up or selected in the list, a menu opens where the user can adjust parameters
+## Step Viewer and Workflow
+The GUI focuses on a streamlined turning workflow. When you load a part, the **Part Setup** tab is displayed. The bottom portion contains a timeline of four machining steps:
 
-  ### Atomatic Toolpath Generation
-  The User can click a button and the following steps are automated.
-  - The standard order of operations is automatically added to the toolpath list <br>
+1. **Contouring**
+2. **Threading**
+3. **Chamfering**
+4. **Parting**
 
-    Facing &rarr; Drilling &rarr; Internal Roughing &rarr; Internal Finishing &rarr; External Roughing &rarr; External Finishing &rarr; Parting <br>
+These steps are automatically generated in this order. Each step can be toggled on or off and expanded to adjust parameters. The order in the timeline reflects the machining sequence.
 
-    (If the part doesnt have internal features for example, the corresponding steps will be skipped)
+## Simulation
+A built-in simulation with collision detection runs after toolpaths are generated, similar to the preview in 3D printing slicers.
 
-  ### Simulation
-  A simulation combinded with collision detection will be automatically invoked (Similiar to 3D-Printing Slicers)
-
-  ### Tools
-  - This set of Tools will be supported and things will be optimized for them. https://www.paulimot.de/drehmeissel-set/mit_wendeplatte/12mm-
-
-    
-  - However Users can add their own tools via a wizard that takes the official ISO Codes and convert them to geometry
-    
+## Tools
+A default set of turning tools is provided, but users can add custom tools via a wizard that accepts standard ISO codes and converts them to geometry.

--- a/docs/index.md
+++ b/docs/index.md
@@ -12,10 +12,11 @@ Whether you’re a user looking to generate your first turning job or a develope
 - [Windows Setup Guide](windows_setup.md)  
   Comprehensive Windows-specific setup guide with tested configuration and troubleshooting.
 
-- [Getting Started](getting_started.md)  
+- [Getting Started](getting_started.md)
   Quick tutorial to import a model, define your setup, and generate your first toolpaths.
-
-- [Chuck Management User Guide](user_guide_chuck.md)  
+- [Toolpath Workflow](toolpath_workflow.md)
+  Overview of the default machining steps and how to configure them.
+- [Chuck Management User Guide](user_guide_chuck.md)
   Complete guide to using the 3-jaw chuck management and workpiece alignment features.
 
 - [Architecture Overview](architecture.md)  

--- a/docs/toolpath_workflow.md
+++ b/docs/toolpath_workflow.md
@@ -1,0 +1,10 @@
+# Toolpath Workflow
+
+When a part is loaded, IntuiCAM creates four default machining steps:
+
+1. **Contouring**
+2. **Threading**
+3. **Chamfering**
+4. **Parting**
+
+These steps are shown as a timeline in the GUI. Each step can be enabled or disabled and configured before toolpaths are generated. Additional operations will be added in the future, but the default workflow provides a quick path from model import to simulation and G-code export.


### PR DESCRIPTION
## Summary
- align documentation with automatic Contouring→Threading→Chamfering→Parting workflow
- describe updated Part Setup tab and timeline-based operations
- simplify GUI and core design docs
- add dedicated toolpath workflow page and link from index

## Testing
- `ctest --output-on-failure`

------
https://chatgpt.com/codex/tasks/task_e_684b2ab5b5ac8332a5bf0963bb03c10e