### PR TITLE
Fix visibility toggle rendering mode

### DIFF
--- a/gui/src/chuckmanager.cpp
+++ b/gui/src/chuckmanager.cpp
@@ -308,7 +308,9 @@ void ChuckManager::setChuckVisible(bool visible)
 
     if (visible) {
         if (!m_context->IsDisplayed(m_chuckAIS)) {
-            m_context->Display(m_chuckAIS, Standard_False);
+            m_context->Display(m_chuckAIS, AIS_Shaded, 0, Standard_False);
+            // Keep chuck non-selectable when redisplayed
+            m_context->Deactivate(m_chuckAIS);
         }
     } else {
         m_context->Erase(m_chuckAIS, Standard_False);

--- a/gui/src/rawmaterialmanager.cpp
+++ b/gui/src/rawmaterialmanager.cpp
@@ -179,7 +179,9 @@ void RawMaterialManager::setRawMaterialVisible(bool visible)
 
     if (visible) {
         if (!m_context->IsDisplayed(m_rawMaterialAIS)) {
-            m_context->Display(m_rawMaterialAIS, Standard_False);
+            m_context->Display(m_rawMaterialAIS, AIS_Shaded, 0, Standard_False);
+            // Keep raw material non-selectable when redisplayed
+            makeRawMaterialNonSelectable();
         }
     } else {
         m_context->Erase(m_rawMaterialAIS, Standard_False);

--- a/gui/src/workpiecemanager.cpp
+++ b/gui/src/workpiecemanager.cpp
@@ -342,7 +342,7 @@ void WorkpieceManager::setWorkpiecesVisible(bool visible)
         if (!workpiece.IsNull()) {
             if (visible) {
                 if (!m_context->IsDisplayed(workpiece)) {
-                    m_context->Display(workpiece, Standard_False);
+                    m_context->Display(workpiece, AIS_Shaded, 0, Standard_False);
                 }
             } else {
                 m_context->Erase(workpiece, Standard_False);


### PR DESCRIPTION
## Summary
- ensure shapes reappear in shaded mode when toggling visibility
- keep chuck and raw material nonselectable when redisplayed

## Testing
- `cmake .. -DCMAKE_BUILD_TYPE=Debug` *(fails: Qt6 not found)*

------
https://chatgpt.com/codex/tasks/task_e_684b2df8e0588332bcfc9d5583fdfbc8