### PR TITLE
Fix build errors in GUI and parting operation

### DIFF
--- a/core/toolpath/include/IntuiCAM/Toolpath/PartingOperation.h
+++ b/core/toolpath/include/IntuiCAM/Toolpath/PartingOperation.h
@@ -12,6 +12,7 @@ public:
         double partingDiameter = 20.0;  // mm
         double partingZ = -50.0;        // mm
         double centerHoleDiameter = 3.0; // mm (0 for solid)
+        double partingWidth = 3.0;      // mm width of cut
         double feedRate = 0.02;         // mm/rev
         double retractDistance = 2.0;   // mm
     };

--- a/gui/include/setupconfigurationpanel.h
+++ b/gui/include/setupconfigurationpanel.h
@@ -193,12 +193,12 @@ private:
 
     QGroupBox* m_operationsGroup;
     QVBoxLayout* m_operationsLayout;
-    QCheckBox* m_contouringEnabledCheck;
-    QPushButton* m_contouringParamsButton;
-    QCheckBox* m_threadingEnabledCheck;
-    QPushButton* m_threadingParamsButton;
-    QCheckBox* m_chamferingEnabledCheck;
-    QPushButton* m_chamferingParamsButton;
+    QCheckBox* m_facingEnabledCheck;
+    QPushButton* m_facingParamsButton;
+    QCheckBox* m_roughingEnabledCheck;
+    QPushButton* m_roughingParamsButton;
+    QCheckBox* m_finishingEnabledCheck;
+    QPushButton* m_finishingParamsButton;
     QCheckBox* m_partingEnabledCheck;
     QPushButton* m_partingParamsButton;
 


### PR DESCRIPTION
## Summary
- define missing checkbox and button members for machining operations
- add `partingWidth` field to PartingOperation parameters

## Testing
- `cmake -S . -B build -GNinja` *(fails: Qt6 not found)*

------
https://chatgpt.com/codex/tasks/task_e_684b3268bd108332a0b3d848c4304eeb