### PR TITLE
Fix build warnings in Types and ChuckManager

### DIFF
--- a/core/toolpath/src/Types.cpp
+++ b/core/toolpath/src/Types.cpp
@@ -138,12 +138,5 @@ Operation::Operation(Type type, const std::string& name, std::shared_ptr<Tool> t
     : type_(type), name_(name), tool_(tool) {
 }
 
-std::unique_ptr<Operation> Operation::createOperation(Type type, const std::string& name, 
-                                                     std::shared_ptr<Tool> tool) {
-    // This would create specific operation types
-    // For now, return nullptr as placeholder
-    return nullptr;
-}
-
 } // namespace Toolpath
 } // namespace IntuiCAM 

--- a/gui/src/chuckmanager.cpp
+++ b/gui/src/chuckmanager.cpp
@@ -264,7 +264,7 @@ void ChuckManager::setChuckMaterial(Handle(AIS_Shape) chuckAIS)
     chuckMaterial.SetAmbientColor(Quantity_Color(0.3, 0.3, 0.3, Quantity_TOC_RGB));
     chuckMaterial.SetDiffuseColor(Quantity_Color(0.7, 0.7, 0.7, Quantity_TOC_RGB));
     chuckMaterial.SetSpecularColor(Quantity_Color(0.9, 0.9, 0.9, Quantity_TOC_RGB));
-    chuckMaterial.SetShininess(0.8);
+    chuckMaterial.SetShininess(0.8f);
     
     chuckAIS->SetMaterial(chuckMaterial);
 }


### PR DESCRIPTION
## Summary
- remove duplicate Operation::createOperation implementation
- avoid double-to-float warning when setting shininess

## Testing
- `cmake --preset ninja-debug` *(fails: Could not find toolchain file)*

------
https://chatgpt.com/codex/tasks/task_e_684b36295840833287fc4676e54141de