### PR TITLE
Remove timeline plus button

### DIFF
--- a/gui/include/toolpathtimelinewidget.h
+++ b/gui/include/toolpathtimelinewidget.h
@@ -4,7 +4,6 @@
 #include <QWidget>
 #include <QHBoxLayout>
 #include <QScrollArea>
-#include <QPushButton>
 #include <QVBoxLayout>
 #include <QLabel>
 #include <QFrame>
@@ -122,10 +121,6 @@ public:
     void setToolpathEnabled(int index, bool enabled);
 
 public slots:
-    /**
-     * @brief Handle click on the add toolpath button
-     */
-    void onAddToolpathClicked();
     
     /**
      * @brief Handle parameter editing for a toolpath
@@ -215,10 +210,6 @@ private:
      */
     void updateToolpathFrameStyles();
 
-    /**
-     * @brief Create the add toolpath button and menu
-     */
-    void createAddToolpathButton();
 
     /**
      * @brief Event filter for handling events on child widgets
@@ -229,8 +220,6 @@ private:
     QScrollArea* m_scrollArea;
     QWidget* m_timelineContainer;
     QHBoxLayout* m_timelineLayout;
-    QPushButton* m_addToolpathButton;
-    QMenu* m_addToolpathMenu;
 
     // Toolpath data
     QVector<QFrame*> m_toolpathFrames;

--- a/gui/src/toolpathtimelinewidget.cpp
+++ b/gui/src/toolpathtimelinewidget.cpp
@@ -39,9 +39,11 @@ ToolpathTimelineWidget::ToolpathTimelineWidget(QWidget *parent)
     
     // Set standard operations
     m_standardOperations << "Contouring" << "Threading" << "Chamfering" << "Parting";
-    
-    // Create add toolpath button (after setting standard operations)
-    createAddToolpathButton();
+
+    // Create default tiles for each standard operation
+    for (const QString& op : m_standardOperations) {
+        addToolpath(op, op, "Default Tool");
+    }
     
     // Set stylesheet
     setStyleSheet(
@@ -76,23 +78,6 @@ ToolpathTimelineWidget::ToolpathTimelineWidget(QWidget *parent)
         "  font-style: italic;"
         "  font-size: 9pt;"
         "}"
-        "QPushButton#addToolpathButton {"
-        "  background-color: #4080C0;"
-        "  color: white;"
-        "  border-radius: 4px;"
-        "  padding: 4px 8px;"
-        "  font-weight: bold;"
-        "  min-width: 30px;"
-        "  min-height: 70px;"
-        "  max-width: 30px;"
-        "  text-align: center;"
-        "}"
-        "QPushButton#addToolpathButton:hover {"
-        "  background-color: #5090D0;"
-        "}"
-        "QPushButton#addToolpathButton:pressed {"
-        "  background-color: #3070B0;"
-        "}"
     );
 }
 
@@ -110,7 +95,7 @@ int ToolpathTimelineWidget::addToolpath(const QString& operationName,
     QFrame* frame = createToolpathFrame(operationName, operationType, toolName, icon);
     
     // Insert before the add button
-    int index = m_timelineLayout->count() - 1;
+    int index = m_timelineLayout->count();
     m_timelineLayout->insertWidget(index, frame);
     
     // Store the frame, operation type, and operation name
@@ -234,12 +219,6 @@ void ToolpathTimelineWidget::setToolpathEnabled(int index, bool enabled)
     m_enabledChecks.at(index)->setChecked(enabled);
 }
 
-void ToolpathTimelineWidget::onAddToolpathClicked()
-{
-    // Show the add toolpath menu
-    QPoint pos = m_addToolpathButton->mapToGlobal(QPoint(0, m_addToolpathButton->height()));
-    m_addToolpathMenu->popup(pos);
-}
 
 void ToolpathTimelineWidget::onToolpathClicked(int index)
 {
@@ -433,28 +412,6 @@ void ToolpathTimelineWidget::updateToolpathFrameStyles()
     }
 }
 
-void ToolpathTimelineWidget::createAddToolpathButton()
-{
-    // Create add toolpath button
-    m_addToolpathButton = new QPushButton("+", m_timelineContainer);
-    m_addToolpathButton->setObjectName("addToolpathButton");
-    m_addToolpathButton->setToolTip("Add new toolpath");
-    m_addToolpathButton->setFixedWidth(30);
-    m_addToolpathButton->setMinimumHeight(70);
-    m_timelineLayout->addWidget(m_addToolpathButton);
-    
-    // Connect button click
-    connect(m_addToolpathButton, &QPushButton::clicked, this, &ToolpathTimelineWidget::onAddToolpathClicked);
-    
-    // Create add toolpath menu
-    m_addToolpathMenu = new QMenu(this);
-    
-    // Add standard operations
-    for (const QString& operation : m_standardOperations) {
-        QAction* action = m_addToolpathMenu->addAction(operation);
-        connect(action, &QAction::triggered, this, &ToolpathTimelineWidget::onOperationTypeSelected);
-    }
-}
 
 // Override event filter to handle mouse events on toolpath frames
 bool ToolpathTimelineWidget::event(QEvent* event)

--- a/gui/tests/test_plusbuttonworkflow.cpp
+++ b/gui/tests/test_plusbuttonworkflow.cpp
@@ -6,45 +6,19 @@
 class PlusButtonWorkflowTest : public QObject {
     Q_OBJECT
 private slots:
-        // Ensure the add-toolpath menu emits the expected signal when the '+' button is used
-        void testPlusButtonEmitsAddToolpathRequested();
+        // Verify that the timeline no longer exposes an add-toolpath '+' button
+        void testPlusButtonRemoved();
 };
 
-void PlusButtonWorkflowTest::testPlusButtonEmitsAddToolpathRequested()
+void PlusButtonWorkflowTest::testPlusButtonRemoved()
 {
-    // GIVEN a fresh timeline widget with the + button enabled
+    // GIVEN a fresh timeline widget
     ToolpathTimelineWidget widget;
-    widget.setAddButtonEnabled(true);
     widget.show();
 
-    // Spy on the addToolpathRequested signal
-    QSignalSpy addSpy(&widget, &ToolpathTimelineWidget::addToolpathRequested);
-    QVERIFY(addSpy.isValid());
-
-    // Locate the '+' button – it has the objectName set in the implementation
+    // THEN no child button with the old object name should exist
     QPushButton *plusBtn = widget.findChild<QPushButton*>("addToolpathButton");
-    QVERIFY2(plusBtn, "Unable to locate '+' button");
-
-    // WHEN the '+' button is clicked and the very first item in the popup menu is triggered
-    // 1) Simulate the mouse click which opens the popup menu
-    QTest::mouseClick(plusBtn, Qt::LeftButton);
-
-    // 2) Grab the popup menu that was created inside the widget
-    QMenu *popupMenu = widget.findChild<QMenu*>();
-    QVERIFY2(popupMenu, "Popup \"Add Toolpath\" menu not found");
-
-    // Trigger the first action (typically "Facing")
-    QAction *firstAction = popupMenu->actions().first();
-    QVERIFY2(firstAction, "No action found in popup menu");
-    firstAction->trigger();
-
-    // THEN the timeline widget must emit exactly one addToolpathRequested signal
-    QVERIFY2(addSpy.wait(250), "addToolpathRequested signal not emitted in time");
-    QCOMPARE(addSpy.count(), 1);
-    const QList<QVariant> arguments = addSpy.takeFirst();
-
-    // Verify the payload is non-empty (e.g. "Facing", "Roughing"…)
-    QVERIFY(!arguments.at(0).toString().isEmpty());
+    QVERIFY2(!plusBtn, "Unexpected '+' button found in timeline");
 }
 
 QTEST_MAIN(PlusButtonWorkflowTest)


### PR DESCRIPTION
## Summary
- drop timeline add button and menu
- create standard operation tiles at widget startup
- adjust tests for new behavior

## Testing
- `cmake -B build -S . -G Ninja` *(fails: Could not find Qt6Config.cmake)*
- `ctest --output-on-failure` *(no tests found)*

------
https://chatgpt.com/codex/tasks/task_e_684b365a99f48332b107a5ff25e50b34