### PR TITLE
Fix deprecated Qt globalPos usage

### DIFF
--- a/gui/src/toolpathtimelineframe.cpp
+++ b/gui/src/toolpathtimelineframe.cpp
@@ -84,7 +84,7 @@ void ToolpathTimelineFrame::mousePressEvent(QMouseEvent *event)
     if (event->button() == Qt::LeftButton) {
         emit clicked(m_index);
     } else if (event->button() == Qt::RightButton) {
-        emit rightClicked(m_index, event->globalPos());
+        emit rightClicked(m_index, event->globalPosition().toPoint());
     }
     QFrame::mousePressEvent(event);
 } 

--- a/gui/src/toolpathtimelinewidget.cpp
+++ b/gui/src/toolpathtimelinewidget.cpp
@@ -441,7 +441,7 @@ bool ToolpathTimelineWidget::eventFilter(QObject* watched, QEvent* event)
                 onToolpathClicked(index);
                 return true;
             } else if (mouseEvent->button() == Qt::RightButton) {
-                onToolpathRightClicked(index, mouseEvent->globalPos());
+                onToolpathRightClicked(index, mouseEvent->globalPosition().toPoint());
                 return true;
             }
         }


### PR DESCRIPTION
## Summary
- replace deprecated `QMouseEvent::globalPos()` with `globalPosition().toPoint()`

## Testing
- `cmake -B build -S .` *(fails: Could not find package configuration file provided by "Qt6"*)

------
https://chatgpt.com/codex/tasks/task_e_684b3b802e388332ba5f5c876a42bf7d