### PR TITLE
Fix raw material transform check

### DIFF
--- a/gui/src/rawmaterialmanager.cpp
+++ b/gui/src/rawmaterialmanager.cpp
@@ -344,7 +344,7 @@ double RawMaterialManager::calculateOptimalLengthWithTransform(const TopoDS_Shap
     try {
         // Apply transformation to the workpiece for calculation
         TopoDS_Shape transformedWorkpiece = workpiece;
-        if (!transform.Form() == gp_Identity) {
+        if (transform.Form() != gp_Identity) {
             BRepBuilderAPI_Transform transformer(workpiece, transform);
             transformedWorkpiece = transformer.Shape();
         }
@@ -516,7 +516,7 @@ TopoDS_Shape RawMaterialManager::createCylinderForWorkpieceWithTransform(double 
         
         // Apply transformation to the workpiece for bounding box calculation
         TopoDS_Shape transformedWorkpiece = workpiece;
-        if (!transform.Form() == gp_Identity) {
+        if (transform.Form() != gp_Identity) {
             BRepBuilderAPI_Transform transformer(workpiece, transform);
             transformedWorkpiece = transformer.Shape();
         }


### PR DESCRIPTION
## Summary
- fix conditional when checking for identity transforms in raw material calculations

## Testing
- `cmake ..` *(fails: Qt6 not found)*

------
https://chatgpt.com/codex/tasks/task_e_684b3ad63b048332a8d8e74462609a2b