### PR TITLE
Integrate vcpkg builds

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,14 +16,21 @@ jobs:
 
     steps:
       - uses: actions/checkout@v3
-      - name: Configure CMake
-        run: cmake -S . -B build -DCMAKE_BUILD_TYPE=Release
-      - name: Build
-        run: cmake --build build --config Release
-      - name: Run Tests
+      - name: Bootstrap vcpkg
         run: |
-          cd build
-          ctest --output-on-failure
+          git clone https://github.com/microsoft/vcpkg
+          if [ "$RUNNER_OS" = "Windows" ]; then
+            .\\vcpkg\\bootstrap-vcpkg.bat
+          else
+            ./vcpkg/bootstrap-vcpkg.sh
+          fi
+        shell: bash
+      - name: Configure CMake
+        run: cmake --preset ninja-release
+      - name: Build
+        run: cmake --build --preset ninja-release
+      - name: Run Tests
+        run: cmake --build --preset ninja-release --target test
       - name: Run clang-format check
         run: |
           git diff --exit-code -- . ':(exclude)**/.github/**'

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -14,66 +14,16 @@ option(INTUICAM_BUILD_CLI "Build the IntuiCAM command-line interface" ON)
 option(INTUICAM_BUILD_PYTHON "Build Python bindings for Core libraries" OFF)
 option(INTUICAM_BUILD_TESTS "Build unit and integration tests" ON)
 
-# Set Qt, VTK, and OpenCASCADE paths
-if(NOT DEFINED CMAKE_PREFIX_PATH)
-  set(CMAKE_PREFIX_PATH "")
-endif()
-
-list(APPEND CMAKE_PREFIX_PATH "C:/Qt/6.9.0/msvc2022_64")
-list(APPEND CMAKE_PREFIX_PATH "C:/OpenCASCADE/3rdparty-vc14-64/vtk-9.4.1-x64/lib/cmake/vtk-9.4")
-list(APPEND CMAKE_PREFIX_PATH "C:/OpenCASCADE/occt-vc144-64-with-debug/cmake")
-
-# Add EGL and other 3rdparty library paths
-link_directories("C:/OpenCASCADE/3rdparty-vc14-64/angle-gles2-2.1.0-vc14-64/lib")
-link_directories("C:/OpenCASCADE/3rdparty-vc14-64/draco-1.4.1-vc14-64/lib")
-link_directories("C:/OpenCASCADE/3rdparty-vc14-64/jemalloc-vc14-64/lib")
-link_directories("C:/OpenCASCADE/3rdparty-vc14-64/openvr-1.14.15-64/lib/win64")
-link_directories("C:/OpenCASCADE/3rdparty-vc14-64/freeimage-3.18.0-x64/lib")
-link_directories("C:/OpenCASCADE/3rdparty-vc14-64/ffmpeg-3.3.4-64/lib")
-link_directories("C:/OpenCASCADE/3rdparty-vc14-64/freetype-2.13.3-x64/lib")
-link_directories("C:/OpenCASCADE/3rdparty-vc14-64/tbb-2021.13.0-x64/lib")
-link_directories("C:/OpenCASCADE/3rdparty-vc14-64/tcltk-8.6.15-x64/lib")
-
-# Add OpenCASCADE library paths
-link_directories("C:/OpenCASCADE/occt-vc144-64-with-debug/win64/vc14/lib")
-link_directories("C:/OpenCASCADE/occt-vc144-64-with-debug/win64/vc14/libd")
 
 # Find Qt6 with components
 find_package(Qt6 REQUIRED COMPONENTS Core Gui Widgets OpenGL OpenGLWidgets)
 qt_standard_project_setup()
 
 # Find VTK first (required by OpenCASCADE)
-set(VTK_DIR "C:/OpenCASCADE/3rdparty-vc14-64/vtk-9.4.1-x64/lib/cmake/vtk-9.4")
 find_package(VTK REQUIRED)
 
 # Set up OpenCASCADE
-set(OpenCASCADE_DIR "C:/OpenCASCADE/occt-vc144-64-with-debug/cmake")
 find_package(OpenCASCADE REQUIRED)
-
-# Fix hardcoded jemalloc path issue in OpenCASCADE configuration
-# Replace incorrect jemalloc path with correct one
-if(TARGET TKernel)
-    get_target_property(TKERNEL_LINK_LIBS TKernel INTERFACE_LINK_LIBRARIES)
-    if(TKERNEL_LINK_LIBS)
-        string(REPLACE "C:/work/occt/3rdparty-vc14-64/jemalloc-vc14-64/lib/jemalloc.lib" 
-                       "C:/OpenCASCADE/3rdparty-vc14-64/jemalloc-vc14-64/lib/jemalloc.lib" 
-                       TKERNEL_LINK_LIBS_FIXED "${TKERNEL_LINK_LIBS}")
-        set_target_properties(TKernel PROPERTIES INTERFACE_LINK_LIBRARIES "${TKERNEL_LINK_LIBS_FIXED}")
-    endif()
-endif()
-
-# Clean up OpenCASCADE compiler flags to avoid duplicates and malformed flags
-if(OpenCASCADE_CXX_FLAGS)
-    string(REGEX REPLACE "/fp:precise" "" OpenCASCADE_CXX_FLAGS_CLEANED "${OpenCASCADE_CXX_FLAGS}")
-    string(REGEX REPLACE "[ ]+" " " OpenCASCADE_CXX_FLAGS_CLEANED "${OpenCASCADE_CXX_FLAGS_CLEANED}")
-    string(STRIP "${OpenCASCADE_CXX_FLAGS_CLEANED}" OpenCASCADE_CXX_FLAGS_CLEANED)
-    set(OpenCASCADE_CXX_FLAGS "${OpenCASCADE_CXX_FLAGS_CLEANED}")
-endif()
-
-# --- Include Directories ---
-include_directories(
-    ${OpenCASCADE_INCLUDE_DIR}
-)
 
 # --- Add Subdirectories ---
 # Core libraries will be added here.

--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -16,7 +16,7 @@
       },
       "binaryDir": "${sourceDir}/build_vs",
       "cacheVariables": {
-        "CMAKE_TOOLCHAIN_FILE": "$env{USERPROFILE}/vcpkg/scripts/buildsystems/vcpkg.cmake"
+        "CMAKE_TOOLCHAIN_FILE": "${sourceDir}/vcpkg/scripts/buildsystems/vcpkg.cmake"
       }
     },
     {
@@ -41,7 +41,7 @@
       "generator": "Ninja",
       "binaryDir": "${sourceDir}/build_ninja",
       "cacheVariables": {
-        "CMAKE_TOOLCHAIN_FILE": "$env{USERPROFILE}/vcpkg/scripts/buildsystems/vcpkg.cmake"
+        "CMAKE_TOOLCHAIN_FILE": "${sourceDir}/vcpkg/scripts/buildsystems/vcpkg.cmake"
       }
     },
     {

--- a/README.md
+++ b/README.md
@@ -53,33 +53,22 @@ For common build and runtime issues, see [docs/troubleshooting.md](docs/troubles
 ✅ **OpenCASCADE Integration** - Updated to use current library names (TKDESTEP, TKDEIGES, etc.)  
 ✅ **3D Visualization Ready** - OpenGL widget with STEP file import capability  
 
-#### Windows (Tested Configuration)
-
-**Requirements:**
-- Visual Studio 2019/2022 with C++ workload
-- Qt 6.9.0 for MSVC 2022 (installed to `C:/Qt/6.9.0/msvc2022_64`)
-- OpenCASCADE 7.6.0 with 3rdparty dependencies (installed to `C:/OpenCASCADE/`)
+#### Windows (via vcpkg)
 
 ```powershell
 git clone https://github.com/your-org/IntuiCAM.git
 cd IntuiCAM
+git clone https://github.com/microsoft/vcpkg
+.\vcpkg\bootstrap-vcpkg.bat
 
-# Create and enter build directory
-mkdir build
-cd build
+cmake --preset ninja-release
+cmake --build --preset ninja-release
 
-# Configure (CMake will find dependencies automatically)
-cmake .. -DCMAKE_BUILD_TYPE=Release
-
-# Build all targets
-cmake --build . --config Release
-
-# Run the applications (Note: All required DLLs are automatically copied)
-.\Release\IntuiCAMGui.exe    # Qt GUI Application (self-contained with all DLLs)
-.\Release\IntuiCAMCli.exe    # Command Line Interface
+.\build_ninja\IntuiCAMGui.exe    # Qt GUI Application
+.\build_ninja\IntuiCAMCli.exe    # Command Line Interface
 ```
 
-**Note:** All required runtime DLLs are automatically copied during build, including Qt6, OpenCASCADE 3rd party libraries (TBB, FreeImage, FFmpeg, OpenVR, Jemalloc, etc.), and VTK libraries. No additional PATH configuration is required.
+**Note:** vcpkg installs all runtime dependencies and `windeployqt` is invoked automatically during the build, so no manual DLL copying or PATH setup is necessary.
 
 ### Current GUI Features
 
@@ -105,15 +94,12 @@ The main window now includes:
 ```bash
 git clone https://github.com/your-org/IntuiCAM.git
 cd IntuiCAM
+git clone https://github.com/microsoft/vcpkg
+./vcpkg/bootstrap-vcpkg.sh
 
-# Create build directory
-mkdir build && cd build
+cmake --preset ninja-release
+cmake --build --preset ninja-release
 
-# Configure and build
-cmake .. -DCMAKE_BUILD_TYPE=Release
-cmake --build . --parallel
-
-# Run the applications
-./bin/IntuiCAMGui    # Qt GUI Application  
-./bin/IntuiCAMCli    # Command Line Interface
+./build_ninja/IntuiCAMGui    # Qt GUI Application
+./build_ninja/IntuiCAMCli    # Command Line Interface
 ```

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -63,10 +63,8 @@ vcpkg is the recommended way to manage dependencies on Windows as it ensures con
 
 4. **Build with vcpkg integration**:
    ```powershell
-   mkdir build
-   cd build
-   cmake .. -DCMAKE_TOOLCHAIN_FILE=[path\to\vcpkg]\scripts\buildsystems\vcpkg.cmake
-   cmake --build . --config Release
+   cmake --preset ninja-release
+   cmake --build --preset ninja-release
    ```
 
 ### 2.2 Manual Installation (Tested Configuration)
@@ -108,10 +106,8 @@ vcpkg is the recommended way to manage dependencies on Windows as it ensures con
    ```
 
 **Important Notes**:
-- The CMakeLists.txt is pre-configured for the standard installation paths
-- **All required runtime DLLs are automatically copied** to the output directory during build, including Qt6, OpenCASCADE 3rd party libraries (TBB, FreeImage, FFmpeg, OpenVR, Jemalloc, etc.), and VTK dependencies
-- **No PATH configuration is required** - the application is self-contained
-- If you install to different locations, you may need to modify the paths in the root CMakeLists.txt file
+- vcpkg installs all dependencies automatically and `windeployqt` runs during the build.
+- No manual copying of DLLs or PATH configuration is required.
 
 ---
 
@@ -152,9 +148,10 @@ vcpkg is the recommended way to manage dependencies on Windows as it ensures con
    ```bash
    git clone https://github.com/your-org/IntuiCAM.git
    cd IntuiCAM
-   mkdir build && cd build
-   cmake .. -DCMAKE_BUILD_TYPE=Release
-   make -j$(nproc)
+   git clone https://github.com/microsoft/vcpkg
+   ./vcpkg/bootstrap-vcpkg.sh
+   cmake --preset ninja-release
+   cmake --build --preset ninja-release
    ```
 
 ### 3.2 Fedora/RHEL
@@ -191,9 +188,10 @@ vcpkg is the recommended way to manage dependencies on Windows as it ensures con
    ```bash
    git clone https://github.com/your-org/IntuiCAM.git
    cd IntuiCAM
-   mkdir build && cd build
-   cmake .. -DCMAKE_BUILD_TYPE=Release
-   make -j$(sysctl -n hw.ncpu)
+   git clone https://github.com/microsoft/vcpkg
+   ./vcpkg/bootstrap-vcpkg.sh
+   cmake --preset ninja-release
+   cmake --build --preset ninja-release
    ```
 
 ---

--- a/gui/CMakeLists.txt
+++ b/gui/CMakeLists.txt
@@ -145,78 +145,12 @@ set_target_properties(${GUI_EXECUTABLE_NAME} PROPERTIES
 # (target_link_libraries above handles include dirs for compilation of gui sources against core public headers)
 # However, if gui/src itself needs to #include <IntuiCAM/CoreModule/Header.h>, this is handled by core modules exporting their include directories.
 
-# Copy required DLLs to output directory for runtime dependency resolution
+# Deploy Qt libraries on Windows
 if(WIN32)
-    # Define essential DLLs that are commonly required by OpenCASCADE applications
-    # This approach is more selective than copying entire bin directories
-    set(REQUIRED_DLLS
-        # TBB (Threading Building Blocks) - Essential for parallel processing
-        "C:/OpenCASCADE/3rdparty-vc14-64/tbb-2021.13.0-x64/bin/tbb12.dll"
-        "C:/OpenCASCADE/3rdparty-vc14-64/tbb-2021.13.0-x64/bin/tbb12_debug.dll"
-        "C:/OpenCASCADE/3rdparty-vc14-64/tbb-2021.13.0-x64/bin/tbbmalloc.dll"
-        
-        # FreeImage - Image processing
-        "C:/OpenCASCADE/3rdparty-vc14-64/freeimage-3.18.0-x64/bin/FreeImage.dll"
-        
-        # FreeType - Font rendering
-        "C:/OpenCASCADE/3rdparty-vc14-64/freetype-2.13.3-x64/bin/freetype.dll"
-        
-        # TCL/TK - Scripting support
-        "C:/OpenCASCADE/3rdparty-vc14-64/tcltk-8.6.15-x64/bin/tcl86.dll"
-        "C:/OpenCASCADE/3rdparty-vc14-64/tcltk-8.6.15-x64/bin/tk86.dll"
-        "C:/OpenCASCADE/3rdparty-vc14-64/tcltk-8.6.15-x64/bin/zlib1.dll"
-        
-        # Jemalloc - Memory allocator (critical for OpenCASCADE)
-        "C:/OpenCASCADE/3rdparty-vc14-64/jemalloc-vc14-64/bin/jemalloc.dll"
-        
-        # OpenGL ES / EGL - Graphics support (ANGLE)
-        "C:/OpenCASCADE/3rdparty-vc14-64/angle-gles2-2.1.0-vc14-64/bin/libEGL.dll"
-        "C:/OpenCASCADE/3rdparty-vc14-64/angle-gles2-2.1.0-vc14-64/bin/libGLESv2.dll"
-        "C:/OpenCASCADE/3rdparty-vc14-64/angle-gles2-2.1.0-vc14-64/bin/d3dcompiler_47.dll"
-        
-        # OpenVR - Virtual Reality support (if needed)
-        "C:/OpenCASCADE/3rdparty-vc14-64/openvr-1.14.15-64/bin/win64/openvr_api.dll"
-        
-        # FFmpeg - Video/multimedia support
-        "C:/OpenCASCADE/3rdparty-vc14-64/ffmpeg-3.3.4-64/bin/avcodec-57.dll"
-        "C:/OpenCASCADE/3rdparty-vc14-64/ffmpeg-3.3.4-64/bin/avdevice-57.dll"
-        "C:/OpenCASCADE/3rdparty-vc14-64/ffmpeg-3.3.4-64/bin/avfilter-6.dll"
-        "C:/OpenCASCADE/3rdparty-vc14-64/ffmpeg-3.3.4-64/bin/avformat-57.dll"
-        "C:/OpenCASCADE/3rdparty-vc14-64/ffmpeg-3.3.4-64/bin/avutil-55.dll"
-        "C:/OpenCASCADE/3rdparty-vc14-64/ffmpeg-3.3.4-64/bin/swscale-4.dll"
-    )
-    
-    # Copy only essential DLLs that exist
-    foreach(DLL_FILE ${REQUIRED_DLLS})
-        if(EXISTS ${DLL_FILE})
-            add_custom_command(TARGET ${GUI_EXECUTABLE_NAME} POST_BUILD
-                COMMAND ${CMAKE_COMMAND} -E copy_if_different
-                "${DLL_FILE}"
-                "$<TARGET_FILE_DIR:${GUI_EXECUTABLE_NAME}>"
-                COMMENT "Copying essential DLL: ${DLL_FILE}"
-            )
-        else()
-            message(STATUS "Warning: DLL not found: ${DLL_FILE}")
-        endif()
-    endforeach()
-    
-    # Copy VTK DLLs (these are numerous, so we'll copy the essential ones)
-    set(VTK_BIN_PATH "C:/OpenCASCADE/3rdparty-vc14-64/vtk-9.4.1-x64/bin")
-    if(EXISTS ${VTK_BIN_PATH})
-        # Copy core VTK DLLs that OpenCASCADE typically needs
-        file(GLOB VTK_CORE_DLLS 
-            "${VTK_BIN_PATH}/vtkCommon*.dll"
-            "${VTK_BIN_PATH}/vtkRendering*.dll"
-            "${VTK_BIN_PATH}/vtkFiltering*.dll"
-            "${VTK_BIN_PATH}/vtkIO*.dll"
-        )
-        foreach(VTK_DLL ${VTK_CORE_DLLS})
-            add_custom_command(TARGET ${GUI_EXECUTABLE_NAME} POST_BUILD
-                COMMAND ${CMAKE_COMMAND} -E copy_if_different
-                "${VTK_DLL}"
-                "$<TARGET_FILE_DIR:${GUI_EXECUTABLE_NAME}>"
-                COMMENT "Copying VTK DLL: ${VTK_DLL}"
-            )
-        endforeach()
+    find_program(WINDEPLOYQT_EXECUTABLE windeployqt)
+    if(WINDEPLOYQT_EXECUTABLE)
+        add_custom_command(TARGET ${GUI_EXECUTABLE_NAME} POST_BUILD
+            COMMAND ${WINDEPLOYQT_EXECUTABLE} "$<TARGET_FILE:${GUI_EXECUTABLE_NAME}>"
+            COMMENT "Deploying Qt runtime")
     endif()
 endif()

--- a/vcpkg.json
+++ b/vcpkg.json
@@ -1,0 +1,22 @@
+{
+  "name": "intuicam",
+  "version-string": "1.0.0",
+  "dependencies": [
+    {
+      "name": "qt",
+      "version>=" : "6.2.0",
+      "default-features": false,
+      "features": ["widgets", "gui", "3d"]
+    },
+    {
+      "name": "opencascade",
+      "version>=" : "7.6.0"
+    },
+    "eigen3",
+    "pybind11",
+    {
+      "name": "gtest",
+      "host": true
+    }
+  ]
+}


### PR DESCRIPTION
## Summary
- add `vcpkg.json` with dependency definitions
- configure all CMake presets to use the bundled vcpkg toolchain
- rely on `find_package` instead of custom paths in CMakeLists.txt
- remove manual DLL copying and run `windeployqt` instead
- bootstrap vcpkg in CI and build from presets
- document the simplified vcpkg-based workflow

## Testing
- `cmake --preset ninja-release` *(fails: Could not find vcpkg toolchain)*

------
https://chatgpt.com/codex/tasks/task_e_684b3cf66bb483328d4227562911f7ca