### PR TITLE
Fix raw material transform check

### DIFF
--- a/gui/src/mainwindow.cpp
+++ b/gui/src/mainwindow.cpp
@@ -1293,13 +1293,6 @@ void MainWindow::handleStepFileSelected(const QString& filePath)
                     m_3dViewer->fitAll();
                 }
 
-                if (m_toolpathTimeline) {
-                    m_toolpathTimeline->clearToolpaths();
-                    QStringList ops = {"Contouring", "Threading", "Chamfering", "Parting"};
-                    for (const QString& op : ops) {
-                        m_toolpathTimeline->addToolpath(op, op, "Default Tool");
-                    }
-                }
             } else {
                 QString errorMsg = "Failed to process workpiece through workspace controller";
                 statusBar()->showMessage(errorMsg, 5000);

--- a/gui/src/rawmaterialmanager.cpp
+++ b/gui/src/rawmaterialmanager.cpp
@@ -344,7 +344,7 @@ double RawMaterialManager::calculateOptimalLengthWithTransform(const TopoDS_Shap
     try {
         // Apply transformation to the workpiece for calculation
         TopoDS_Shape transformedWorkpiece = workpiece;
-        if (!transform.Form() == gp_Identity) {
+        if (transform.Form() != gp_Identity) {
             BRepBuilderAPI_Transform transformer(workpiece, transform);
             transformedWorkpiece = transformer.Shape();
         }
@@ -516,7 +516,7 @@ TopoDS_Shape RawMaterialManager::createCylinderForWorkpieceWithTransform(double 
         
         // Apply transformation to the workpiece for bounding box calculation
         TopoDS_Shape transformedWorkpiece = workpiece;
-        if (!transform.Form() == gp_Identity) {
+        if (transform.Form() != gp_Identity) {
             BRepBuilderAPI_Transform transformer(workpiece, transform);
             transformedWorkpiece = transformer.Shape();
         }


### PR DESCRIPTION
## Summary
- fix conditional when checking for identity transforms in raw material calculations
- avoid clearing timeline when step file is selected because standard operations load automatically

## Testing
- `cmake -S . -B build >/tmp/cmake.log && tail -n 20 /tmp/cmake.log` *(fails: Qt6 not found)*

------
https://chatgpt.com/codex/tasks/task_e_684b3ad63b048332a8d8e74462609a2b