### PR TITLE
Fix crash on part upload by avoiding double delete

### DIFF
--- a/gui/src/toolpathtimelinewidget.cpp
+++ b/gui/src/toolpathtimelinewidget.cpp
@@ -144,7 +144,9 @@ void ToolpathTimelineWidget::clearToolpaths()
         delete frame;
     }
 
-    qDeleteAll(m_enabledChecks);
+    // Clear checkbox list. The actual QCheckBox objects are deleted together
+    // with their parent frames above, so we must not delete them again here to
+    // avoid a double free crash when reloading parts.
     m_enabledChecks.clear();
     
     m_toolpathFrames.clear();


### PR DESCRIPTION
## Summary
- fix crash when reloading parts by clearing checkbox list without deleting already-destroyed checkboxes

## Testing
- `cmake -S . -B build -GNinja` *(fails: Could not find package configuration file provided by "Qt6")*

------
https://chatgpt.com/codex/tasks/task_e_684efd2f76548332a5bc3d393d4fb40b