### PR TITLE
Fix view mode restoration

### DIFF
--- a/docs/gui/coordinate_system_implementation.md
+++ b/docs/gui/coordinate_system_implementation.md
@@ -24,6 +24,7 @@ The following coordinate system improvements have been implemented:
 
 4. **Camera State Preservation**
    - 3D camera state is preserved when switching to XZ view
+   - Projection type (perspective or orthographic) is restored when returning to 3D view
    - XZ view settings are consistent with standard lathe conventions
    - Smooth transition between views with proper handling of different projection types
 

--- a/docs/gui/view_modes.md
+++ b/docs/gui/view_modes.md
@@ -87,7 +87,7 @@ When switching between modes, the 3D camera state is preserved, allowing users t
 2. Return to the exact same 3D view without losing context
 
 ### Camera Management
-- **State Preservation**: When switching away from 3D mode, the camera state (position, orientation, scale) is automatically stored and restored when returning to 3D mode
+ - **State Preservation**: When switching away from 3D mode, the camera state (position, orientation, scale, projection type) is automatically stored and restored when returning to 3D mode
 - **Smooth Transitions**: Camera changes are applied smoothly with proper view fitting
 - **Mode-Specific Settings**: Each mode has optimized camera settings for its intended use
 

--- a/gui/include/opengl3dwidget.h
+++ b/gui/include/opengl3dwidget.h
@@ -29,6 +29,7 @@
 #include <Graphic3d_Group.hxx>
 #include <Graphic3d_ArrayOfSegments.hxx>
 #include <Graphic3d_Structure.hxx>
+#include <Graphic3d_Camera.hxx>
 #include <AIS_Line.hxx>
 #include <Geom_Line.hxx>
 #include <TColgp_Array1OfPnt.hxx>
@@ -246,11 +247,13 @@ private:
 
     /**
      * @brief Store current 3D camera state before switching to lathe mode
+     *        (includes projection type)
      */
     void store3DCameraState();
 
     /**
      * @brief Restore 3D camera state when switching back from lathe mode
+     *        (restores projection type as well)
      */
     void restore3DCameraState();
 
@@ -308,6 +311,7 @@ private:
     gp_Pnt m_stored3DAt;
     gp_Dir m_stored3DUp;
     double m_stored3DScale;
+    Graphic3d_Camera::Projection m_stored3DProjection;
     bool m_has3DCameraState;
 
     // Workspace controller

--- a/gui/src/opengl3dwidget.cpp
+++ b/gui/src/opengl3dwidget.cpp
@@ -43,6 +43,7 @@ OpenGL3DWidget::OpenGL3DWidget(QWidget *parent)
     , m_hoverHighlightEnabled(true)
     , m_currentViewMode(ViewMode::Mode3D)
     , m_stored3DScale(1.0)
+    , m_stored3DProjection(Graphic3d_Camera::Projection_Perspective)
     , m_has3DCameraState(false)
     , m_workspaceController(nullptr)
     , m_gridVisible(false)
@@ -1036,11 +1037,12 @@ void OpenGL3DWidget::store3DCameraState()
         m_view->At(atX, atY, atZ);
         m_view->Eye(eyeX, eyeY, eyeZ);
         m_view->Up(upX, upY, upZ);
-        
+
         m_stored3DAt = gp_Pnt(atX, atY, atZ);
         m_stored3DEye = gp_Pnt(eyeX, eyeY, eyeZ);
         m_stored3DUp = gp_Dir(upX, upY, upZ);
         m_stored3DScale = m_view->Scale();
+        m_stored3DProjection = m_view->Camera()->ProjectionType();
         
         m_has3DCameraState = true;
         
@@ -1070,8 +1072,8 @@ void OpenGL3DWidget::restore3DCameraState()
         m_view->SetUp(m_stored3DUp.X(), m_stored3DUp.Y(), m_stored3DUp.Z());
         m_view->SetScale(m_stored3DScale);
         
-        // Explicitly restore perspective projection for 3D mode
-        m_view->Camera()->SetProjectionType(Graphic3d_Camera::Projection_Perspective);
+        // Restore stored projection type for 3D mode
+        m_view->Camera()->SetProjectionType(m_stored3DProjection);
         
         // Restore trihedron display with standard orientation
         m_view->TriedronErase();


### PR DESCRIPTION
## Summary
- preserve camera projection type when switching between view modes
- document that camera projection is stored and restored

## Testing
- `ctest --output-on-failure`

------
https://chatgpt.com/codex/tasks/task_e_684f01c9e06483329b3ceacdd2e82c4d