### PR TITLE
Fix crash when deleting toolpaths

### DIFF
--- a/gui/src/toolpathtimelinewidget.cpp
+++ b/gui/src/toolpathtimelinewidget.cpp
@@ -121,8 +121,10 @@ void ToolpathTimelineWidget::removeToolpath(int index)
     m_toolpathFrames.remove(index);
     m_toolpathTypes.remove(index);
     m_toolpathNames.remove(index);
-    QCheckBox* chk = m_enabledChecks.takeAt(index);
-    delete chk;
+    // Remove the enable checkbox from our list. It will be deleted together
+    // with its parent frame, so avoid deleting it manually to prevent
+    // double free crashes.
+    m_enabledChecks.takeAt(index);
     delete frame;
     
     // Update active toolpath index if needed


### PR DESCRIPTION
## Summary
- fix double delete when removing toolpaths from the timeline

## Testing
- `cmake -S . -B build -DCMAKE_BUILD_TYPE=Release` *(fails: could not find Qt6)*
- `g++ core/geometry/tests/test_types.cpp ...` *(fails: cannot find -lopencascade_foundation)*

------
https://chatgpt.com/codex/tasks/task_e_684f0241c98483329ed6cf3074007c28