### PR TITLE
Fix operation checkbox crash and sync with timeline

### DIFF
--- a/gui/include/mainwindow.h
+++ b/gui/include/mainwindow.h
@@ -134,6 +134,7 @@ private slots:
     void handleAddToolpathRequested(const QString& operationType);
     void handleRemoveToolpathRequested(int index);
     void handleToolpathReordered(int fromIndex, int toIndex);
+    void handleToolpathEnabledChanged(int index, bool enabled);
 
     // Overlay control for chuck visibility
     void handleShowChuckToggled(bool checked);


### PR DESCRIPTION
## Summary
- make operation tabs scrollable via `QScrollArea`
- ensure operation enable checkboxes emit correct operation names
- block signals when syncing checkbox state
- synchronize operation tabs with timeline tiles

## Testing
- `cmake -S . -B build` *(fails: Qt6 not found)*
- `cmake --build build -j $(nproc)` *(fails: No rule to make target `Makefile`)*

------
https://chatgpt.com/codex/tasks/task_e_684f050749048332bfba3614a0919669