### PR TITLE
Fix crash when enabling operations from Setup tab

### DIFF
--- a/gui/src/setupconfigurationpanel.cpp
+++ b/gui/src/setupconfigurationpanel.cpp
@@ -844,9 +844,13 @@ void SetupConfigurationPanel::onOperationToggled()
         emit operationToggled(operationName, enabled);
         emit configurationChanged();
         updateOperationControls();
-        if (enabled) {
-            emit automaticToolpathGenerationRequested();
-        }
+        // Triggering automatic generation here caused crashes when the
+        // ToolpathGenerationController was not fully initialized.  Until the
+        // generation pipeline is more robust we simply avoid starting it
+        // automatically when toggling an operation from the setup tab.
+        // if (enabled) {
+        //     emit automaticToolpathGenerationRequested();
+        // }
     }
 }
 


### PR DESCRIPTION
## Summary
- prevent auto toolpath generation when enabling operations

## Testing
- `cmake -S . -B build` *(fails: Could not find Qt6)*

------
https://chatgpt.com/codex/tasks/task_e_684f0ac413e08332b9525ecc17f0baa3