### PR TITLE
Move tool parameters into setup tabs

### DIFF
--- a/docs/gui/gui_design.md
+++ b/docs/gui/gui_design.md
@@ -14,7 +14,7 @@ The standard steps are:
 3. **Chamfering** – user selects edges and chamfer size.
 4. **Parting** – defines part‑off strategy.
 
-Users may adjust parameters or disable steps directly from the timeline tabs.
+Selecting a step highlights its tab in the setup panel where all parameters can be edited directly. The separate parameter dialog has been removed.
 
 ### Automatic Generation
 Toolpaths are created as soon as a STEP file is loaded. The timeline always starts with Contouring followed by Threading, Chamfering and Parting. Users simply review the steps and disable or modify them as needed.

--- a/docs/toolpath_workflow.md
+++ b/docs/toolpath_workflow.md
@@ -23,4 +23,6 @@ The left side of the setup tab has been simplified:
 - The **upper half** now contains the part setup controls. Here you upload the STEP file, set the orientation and choose the material type and starting diameter.
 - The **lower half** contains a new tab view with one tab for each machining step (Contouring, Threading, Chamfering, Parting). Each tab lets you choose tools and adjust parameters relevant to that step.
 
+All operation parameters are edited directly in these tabs. The previous parameter dialog window has been removed. Clicking an entry in the timeline automatically focuses the corresponding tab so you can tweak its settings.
+
 These settings are dedicated to lathe turning and are independent for every step.  The timeline at the bottom always shows the steps in the same order, but you can deactivate any of them.

--- a/gui/CMakeLists.txt
+++ b/gui/CMakeLists.txt
@@ -15,7 +15,6 @@ set(GUI_SOURCES
     src/partloadingpanel.cpp
     src/setupconfigurationpanel.cpp
     src/toolpathgenerationcontroller.cpp
-    src/operationparameterdialog.cpp
     src/materialmanager.cpp
     src/toolmanager.cpp
     src/toolpathtimelinewidget.cpp
@@ -33,7 +32,6 @@ set(GUI_HEADERS
     include/partloadingpanel.h
     include/setupconfigurationpanel.h
     include/toolpathgenerationcontroller.h
-    include/operationparameterdialog.h
     include/materialmanager.h
     include/toolmanager.h
     include/toolpathtimelinewidget.h

--- a/gui/include/mainwindow.h
+++ b/gui/include/mainwindow.h
@@ -24,7 +24,6 @@
 #include <TopoDS_Shape.hxx>
 
 // Project includes
-#include "operationparameterdialog.h"
 
 // Forward declarations for our custom classes
 class OpenGL3DWidget;
@@ -110,7 +109,6 @@ private slots:
     void handleRawMaterialDiameterChanged(double diameter);
     void handleManualAxisSelectionRequested();
     void handleOperationToggled(const QString& operationName, bool enabled);
-    void handleOperationParametersRequested(const QString& operationName);
     void handleAutomaticToolpathGeneration();
     
     // 3D viewer handlers

--- a/gui/include/setupconfigurationpanel.h
+++ b/gui/include/setupconfigurationpanel.h
@@ -105,6 +105,7 @@ public:
     QStringList getRecommendedTools() const;
     void updateMaterialProperties();
     void updateToolRecommendations();
+    void focusOperationTab(const QString& operationName);
 
     // Utility methods
     static QString materialTypeToString(MaterialType type);
@@ -121,7 +122,6 @@ signals:
     void orientationFlipped(bool flipped);
     void manualAxisSelectionRequested();
     void operationToggled(const QString& operationName, bool enabled);
-    void operationParametersRequested(const QString& operationName);
     void automaticToolpathGenerationRequested();
     void materialSelectionChanged(const QString& materialName);
     void toolRecommendationsUpdated(const QStringList& toolIds);
@@ -131,7 +131,6 @@ public slots:
     void onConfigurationChanged();
     void onManualAxisSelectionClicked();
     void onOperationToggled();
-    void onOperationParametersClicked();
     void onMaterialChanged();
     void onToolSelectionRequested();
 
@@ -198,13 +197,11 @@ private:
     QGroupBox* m_operationsGroup;
     QVBoxLayout* m_operationsLayout;
     QCheckBox* m_contouringEnabledCheck;
-    QPushButton* m_contouringParamsButton;
     QCheckBox* m_threadingEnabledCheck;
-    QPushButton* m_threadingParamsButton;
+    QDoubleSpinBox* m_threadPitchSpin;
     QCheckBox* m_chamferingEnabledCheck;
-    QPushButton* m_chamferingParamsButton;
+    QDoubleSpinBox* m_chamferSizeSpin;
     QCheckBox* m_partingEnabledCheck;
-    QPushButton* m_partingParamsButton;
 
     QGroupBox* m_qualityGroup;
     QVBoxLayout* m_qualityLayout;

--- a/gui/include/toolpathgenerationcontroller.h
+++ b/gui/include/toolpathgenerationcontroller.h
@@ -21,7 +21,6 @@
 #include <IntuiCAM/Toolpath/PartingOperation.h>
 
 // Include GUI operation parameter dialog
-#include "operationparameterdialog.h"
 
 // Forward declarations
 class ToolpathManager;
@@ -139,8 +138,6 @@ public:
     // New methods for operation parameter updates
     void updateOperationParameters(const QString& operationName, const QString& operationType, void* params);
     void regenerateToolpath(const QString& operationName, const QString& operationType);
-    void connectParameterDialog(OperationParameterDialog* dialog, const QString& operationName, 
-                               const QString& operationType);
     /**
      * @brief Regenerate every currently generated toolpath using updated part position.
      */
@@ -148,7 +145,6 @@ public:
 
 public slots:
     void onGenerationRequested(const GenerationRequest& request);
-    void onOperationParametersChanged(const QString& operationName, const QString& operationType);
 
 signals:
     void generationStarted();

--- a/gui/src/mainwindow.cpp
+++ b/gui/src/mainwindow.cpp
@@ -7,7 +7,6 @@
 #include "toolpathtimelinewidget.h"
 #include "partloadingpanel.h"
 #include "setupconfigurationpanel.h"
-#include "operationparameterdialog.h"
 #include "materialmanager.h"
 #include "toolmanager.h"
 #include "toolpathgenerationcontroller.h"
@@ -315,8 +314,6 @@ void MainWindow::setupConnections()
                 this, &MainWindow::handleAutomaticToolpathGeneration);
         connect(m_setupConfigPanel, &IntuiCAM::GUI::SetupConfigurationPanel::operationToggled,
                 this, &MainWindow::handleOperationToggled);
-        connect(m_setupConfigPanel, &IntuiCAM::GUI::SetupConfigurationPanel::operationParametersRequested,
-                this, &MainWindow::handleOperationParametersRequested);
     }
     
     // Connect simulate button
@@ -345,10 +342,9 @@ void MainWindow::setupConnections()
             m_toolpathTimeline->setToolpathEnabled(i, enabled);
         }
         
-        // REMOVED: Connect to parameters requested signal
-        // This signal is already handled by ToolpathGenerationController
-        // connect(m_toolpathTimeline, &ToolpathTimelineWidget::toolpathParametersRequested,
-        //        this, &MainWindow::handleToolpathParametersRequested);
+        // Focus the appropriate operation tab when parameters are requested
+        connect(m_toolpathTimeline, &ToolpathTimelineWidget::toolpathParametersRequested,
+                this, &MainWindow::handleToolpathParametersRequested);
         
         // REMOVED: Connect to add toolpath requested signal
         // This signal is already handled by ToolpathGenerationController
@@ -1425,13 +1421,6 @@ void MainWindow::handleOperationToggled(const QString& operationName, bool enabl
     }
 }
 
-void MainWindow::handleOperationParametersRequested(const QString& operationName)
-{
-    // Placeholder
-    if (m_outputWindow) {
-        m_outputWindow->append(QString("Parameters requested for operation: %1").arg(operationName));
-    }
-}
 
 void MainWindow::handleAutomaticToolpathGeneration()
 {
@@ -1791,134 +1780,19 @@ void MainWindow::handleToolpathSelected(int index)
     }
     
     // Here you would typically highlight the selected toolpath in the 3D viewer
-    // This depends on how toolpaths are stored and visualized in your application
     statusBar()->showMessage(tr("Selected toolpath %1").arg(index + 1), 2000);
+
+    if (m_toolpathTimeline && m_setupConfigPanel && index >= 0) {
+        QString opType = m_toolpathTimeline->getToolpathType(index);
+        m_setupConfigPanel->focusOperationTab(opType);
+    }
 }
 
 void MainWindow::handleToolpathParametersRequested(int index, const QString& operationType)
 {
-    // NOTE: This method is no longer directly connected to the toolpathTimeline's toolpathParametersRequested signal
-    // as it was causing duplicate parameter windows to be opened. The signal is now exclusively handled by
-    // ToolpathGenerationController. This method is kept for potential future use or manual invocation.
-    
-    // Convert operation type string to enum
-    IntuiCAM::GUI::OperationParameterDialog::OperationType type;
-    
-    if (operationType == "Facing") {
-        type = IntuiCAM::GUI::OperationParameterDialog::OperationType::Facing;
-    } else if (operationType == "Roughing") {
-        type = IntuiCAM::GUI::OperationParameterDialog::OperationType::Roughing;
-    } else if (operationType == "Finishing") {
-        type = IntuiCAM::GUI::OperationParameterDialog::OperationType::Finishing;
-    } else if (operationType == "Parting") {
-        type = IntuiCAM::GUI::OperationParameterDialog::OperationType::Parting;
-    } else {
-        // Default to roughing if type is unknown
-        type = IntuiCAM::GUI::OperationParameterDialog::OperationType::Roughing;
-    }
-    
-    // Create and configure the dialog
-    IntuiCAM::GUI::OperationParameterDialog dialog(type, this);
-    
-    // Set dialog title based on operation type
-    dialog.setWindowTitle(tr("Edit %1 Parameters").arg(operationType));
-    
-    // If we have a workpiece controller, get part diameter to pre-populate fields
-    if (m_workspaceController && m_workspaceController->getWorkpieceManager()) {
-        double diameter = m_workspaceController->getWorkpieceManager()->getDetectedDiameter();
-        
-        // Use raw material diameter as fallback
-        double length = 100.0; // Default length
-        if (m_workspaceController->getRawMaterialManager() && 
-            m_workspaceController->getRawMaterialManager()->isRawMaterialDisplayed()) {
-            // We don't have a direct method to get length, but we have diameter
-            double rawDiameter = m_workspaceController->getRawMaterialManager()->getCurrentDiameter();
-            // Use 3x diameter as a reasonable default length
-            length = rawDiameter * 3.0;
-        }
-        
-        dialog.setPartDiameter(diameter);
-        dialog.setPartLength(length);
-    }
-    
-    // Show the dialog
-    if (dialog.exec() == QDialog::Accepted) {
-        // Handle parameter changes based on operation type
-        switch (type) {
-            case IntuiCAM::GUI::OperationParameterDialog::OperationType::Facing:
-                // Process facing parameters
-                {
-                    auto params = dialog.getFacingParameters();
-                    // Update toolpath with new parameters
-                    // Example: m_workspaceController->updateToolpathParameters(index, params);
-                    
-                    // For now just log to output window
-                    if (m_outputWindow) {
-                        m_outputWindow->append(QString("Updated facing parameters for toolpath %1")
-                                              .arg(index + 1));
-                        m_outputWindow->append(QString("  Stepover: %1 mm").arg(params.stepover));
-                        m_outputWindow->append(QString("  Feed Rate: %1 mm/min").arg(params.feedRate));
-                        m_outputWindow->append(QString("  Stock Allowance: %1 mm").arg(params.stockAllowance));
-                    }
-                }
-                break;
-                
-            case IntuiCAM::GUI::OperationParameterDialog::OperationType::Roughing:
-                // Process roughing parameters
-                {
-                    auto params = dialog.getRoughingParameters();
-                    
-                    if (m_outputWindow) {
-                        m_outputWindow->append(QString("Updated roughing parameters for toolpath %1")
-                                              .arg(index + 1));
-                        m_outputWindow->append(QString("  Depth of Cut: %1 mm").arg(params.depthOfCut));
-                        m_outputWindow->append(QString("  Stock Allowance: %1 mm").arg(params.stockAllowance));
-                        m_outputWindow->append(QString("  Adaptive Clearing: %1").arg(params.adaptiveClearing ? "Yes" : "No"));
-                    }
-                }
-                break;
-                
-            case IntuiCAM::GUI::OperationParameterDialog::OperationType::Finishing:
-                // Process finishing parameters
-                {
-                    auto params = dialog.getFinishingParameters();
-                    
-                    if (m_outputWindow) {
-                        m_outputWindow->append(QString("Updated finishing parameters for toolpath %1")
-                                              .arg(index + 1));
-                        m_outputWindow->append(QString("  Surface Finish: %1 μm Ra").arg(params.targetSurfaceFinish));
-                        m_outputWindow->append(QString("  Radial Stepover: %1 mm").arg(params.radialStepover));
-                        m_outputWindow->append(QString("  Spring Passes: %1").arg(params.multipleSpringPasses ? QString::number(params.springPassCount) : "None"));
-                    }
-                }
-                break;
-                
-            case IntuiCAM::GUI::OperationParameterDialog::OperationType::Parting:
-                // Process parting parameters
-                {
-                    auto params = dialog.getPartingParameters();
-                    
-                    if (m_outputWindow) {
-                        m_outputWindow->append(QString("Updated parting parameters for toolpath %1")
-                                              .arg(index + 1));
-                        m_outputWindow->append(QString("  Feed Rate: %1 mm/min").arg(params.feedRate));
-                        m_outputWindow->append(QString("  Pecking Cycle: %1").arg(params.usePeckingCycle ? "Yes" : "No"));
-                        m_outputWindow->append(QString("  Safety Margin: %1 mm").arg(params.safetyMargin));
-                    }
-                }
-                break;
-        }
-        
-        // Update the toolpath visualization if needed
-        // This would typically involve regenerating the toolpath with new parameters
-        
-        // Update the timeline entry with potentially modified operation name
-        QString toolName = "Default Tool"; // In a real implementation, get this from the tool manager
-        m_toolpathTimeline->updateToolpath(index, 
-                                          tr("%1 #%2").arg(operationType).arg(index + 1),
-                                          operationType, 
-                                          toolName);
-    }
+    Q_UNUSED(index);
+    if (m_setupConfigPanel)
+        m_setupConfigPanel->focusOperationTab(operationType);
 }
 
 void MainWindow::handleAddToolpathRequested(const QString& operationType)

--- a/gui/src/setupconfigurationpanel.cpp
+++ b/gui/src/setupconfigurationpanel.cpp
@@ -74,13 +74,13 @@ SetupConfigurationPanel::SetupConfigurationPanel(QWidget *parent)
     , m_toolManager(nullptr)
     , m_materialPropertiesLabel(nullptr)
     , m_contouringEnabledCheck(nullptr)
-    , m_contouringParamsButton(nullptr)
+    , m_contouringParamsButton(nullptr) /*deprecated*/
     , m_threadingEnabledCheck(nullptr)
-    , m_threadingParamsButton(nullptr)
+    , m_threadingParamsButton(nullptr) /*deprecated*/
     , m_chamferingEnabledCheck(nullptr)
-    , m_chamferingParamsButton(nullptr)
+    , m_chamferingParamsButton(nullptr) /*deprecated*/
     , m_partingEnabledCheck(nullptr)
-    , m_partingParamsButton(nullptr)
+    , m_partingParamsButton(nullptr) /*deprecated*/
 {
     setupUI();
     setupConnections();
@@ -306,11 +306,8 @@ void SetupConfigurationPanel::setupMachiningTab()
 
     QHBoxLayout* contourEnableLayout = new QHBoxLayout();
     m_contouringEnabledCheck = new QCheckBox("Enable Contouring");
-    m_contouringParamsButton = new QPushButton("Parameters...");
-    m_contouringParamsButton->setEnabled(false);
     contourEnableLayout->addWidget(m_contouringEnabledCheck);
     contourEnableLayout->addStretch();
-    contourEnableLayout->addWidget(m_contouringParamsButton);
     contourLayout->addLayout(contourEnableLayout);
 
     m_machiningParamsGroup = new QGroupBox("Machining Parameters");
@@ -440,15 +437,25 @@ void SetupConfigurationPanel::setupMachiningTab()
     threadingLayout->setSpacing(16);
     QHBoxLayout* threadEnableLayout = new QHBoxLayout();
     m_threadingEnabledCheck = new QCheckBox("Enable Threading");
-    m_threadingParamsButton = new QPushButton("Parameters...");
-    m_threadingParamsButton->setEnabled(false);
     threadEnableLayout->addWidget(m_threadingEnabledCheck);
     threadEnableLayout->addStretch();
-    threadEnableLayout->addWidget(m_threadingParamsButton);
     threadingLayout->addLayout(threadEnableLayout);
     QLabel* threadingInfo = new QLabel("Select faces to thread in the 3D view.");
     threadingInfo->setWordWrap(true);
     threadingLayout->addWidget(threadingInfo);
+
+    QHBoxLayout* pitchLayout = new QHBoxLayout();
+    QLabel* pitchLabel = new QLabel("Thread Pitch:");
+    pitchLabel->setMinimumWidth(140);
+    m_threadPitchSpin = new QDoubleSpinBox();
+    m_threadPitchSpin->setRange(0.1, 10.0);
+    m_threadPitchSpin->setValue(1.0);
+    m_threadPitchSpin->setDecimals(2);
+    m_threadPitchSpin->setSuffix(" mm");
+    pitchLayout->addWidget(pitchLabel);
+    pitchLayout->addWidget(m_threadPitchSpin);
+    pitchLayout->addStretch();
+    threadingLayout->addLayout(pitchLayout);
 
     QGroupBox* threadingToolsGroup = new QGroupBox("Recommended Tools");
     QVBoxLayout* threadingToolsLayout = new QVBoxLayout(threadingToolsGroup);
@@ -465,15 +472,25 @@ void SetupConfigurationPanel::setupMachiningTab()
     chamferLayout->setSpacing(16);
     QHBoxLayout* chamferEnableLayout = new QHBoxLayout();
     m_chamferingEnabledCheck = new QCheckBox("Enable Chamfering");
-    m_chamferingParamsButton = new QPushButton("Parameters...");
-    m_chamferingParamsButton->setEnabled(false);
     chamferEnableLayout->addWidget(m_chamferingEnabledCheck);
     chamferEnableLayout->addStretch();
-    chamferEnableLayout->addWidget(m_chamferingParamsButton);
     chamferLayout->addLayout(chamferEnableLayout);
     QLabel* chamferInfo = new QLabel("Select edges to chamfer in the 3D view.");
     chamferInfo->setWordWrap(true);
     chamferLayout->addWidget(chamferInfo);
+
+    QHBoxLayout* chamferSizeLayout = new QHBoxLayout();
+    QLabel* chamferSizeLabel = new QLabel("Chamfer Size:");
+    chamferSizeLabel->setMinimumWidth(140);
+    m_chamferSizeSpin = new QDoubleSpinBox();
+    m_chamferSizeSpin->setRange(0.1, 5.0);
+    m_chamferSizeSpin->setValue(0.5);
+    m_chamferSizeSpin->setDecimals(2);
+    m_chamferSizeSpin->setSuffix(" mm");
+    chamferSizeLayout->addWidget(chamferSizeLabel);
+    chamferSizeLayout->addWidget(m_chamferSizeSpin);
+    chamferSizeLayout->addStretch();
+    chamferLayout->addLayout(chamferSizeLayout);
 
     QGroupBox* chamferToolsGroup = new QGroupBox("Recommended Tools");
     QVBoxLayout* chamferToolsLayout = new QVBoxLayout(chamferToolsGroup);
@@ -490,11 +507,8 @@ void SetupConfigurationPanel::setupMachiningTab()
     partLayout->setSpacing(16);
     QHBoxLayout* partEnableLayout = new QHBoxLayout();
     m_partingEnabledCheck = new QCheckBox("Enable Parting");
-    m_partingParamsButton = new QPushButton("Parameters...");
-    m_partingParamsButton->setEnabled(false);
     partEnableLayout->addWidget(m_partingEnabledCheck);
     partEnableLayout->addStretch();
-    partEnableLayout->addWidget(m_partingParamsButton);
     partLayout->addLayout(partEnableLayout);
     m_partingWidthLayout = new QHBoxLayout();
     m_partingWidthLabel = new QLabel("Parting Width:");
@@ -551,6 +565,8 @@ void SetupConfigurationPanel::setupConnections()
     connect(m_roughingAllowanceSpin, QOverload<double>::of(&QDoubleSpinBox::valueChanged), this, &SetupConfigurationPanel::onConfigurationChanged);
     connect(m_finishingAllowanceSpin, QOverload<double>::of(&QDoubleSpinBox::valueChanged), this, &SetupConfigurationPanel::onConfigurationChanged);
     connect(m_partingWidthSpin, QOverload<double>::of(&QDoubleSpinBox::valueChanged), this, &SetupConfigurationPanel::onConfigurationChanged);
+    connect(m_threadPitchSpin, QOverload<double>::of(&QDoubleSpinBox::valueChanged), this, &SetupConfigurationPanel::onConfigurationChanged);
+    connect(m_chamferSizeSpin, QOverload<double>::of(&QDoubleSpinBox::valueChanged), this, &SetupConfigurationPanel::onConfigurationChanged);
     
     connect(m_surfaceFinishCombo, QOverload<int>::of(&QComboBox::currentIndexChanged), this, &SetupConfigurationPanel::onConfigurationChanged);
     connect(m_toleranceSpin, QOverload<double>::of(&QDoubleSpinBox::valueChanged), this, &SetupConfigurationPanel::onConfigurationChanged);
@@ -569,18 +585,6 @@ void SetupConfigurationPanel::setupConnections()
         connect(m_partingEnabledCheck, &QCheckBox::toggled, this, &SetupConfigurationPanel::onOperationToggled);
     }
 
-    if (m_contouringParamsButton) {
-        connect(m_contouringParamsButton, &QPushButton::clicked, this, &SetupConfigurationPanel::onOperationParametersClicked);
-    }
-    if (m_threadingParamsButton) {
-        connect(m_threadingParamsButton, &QPushButton::clicked, this, &SetupConfigurationPanel::onOperationParametersClicked);
-    }
-    if (m_chamferingParamsButton) {
-        connect(m_chamferingParamsButton, &QPushButton::clicked, this, &SetupConfigurationPanel::onOperationParametersClicked);
-    }
-    if (m_partingParamsButton) {
-        connect(m_partingParamsButton, &QPushButton::clicked, this, &SetupConfigurationPanel::onOperationParametersClicked);
-    }
 }
 
 void SetupConfigurationPanel::applyTabStyling()
@@ -850,21 +854,6 @@ void SetupConfigurationPanel::onOperationToggled()
     }
 }
 
-void SetupConfigurationPanel::onOperationParametersClicked()
-{
-    QPushButton* button = qobject_cast<QPushButton*>(sender());
-    if (button) {
-        QString operationName;
-        if (button == m_contouringParamsButton) operationName = "Contouring";
-        else if (button == m_threadingParamsButton) operationName = "Threading";
-        else if (button == m_chamferingParamsButton) operationName = "Chamfering";
-        else if (button == m_partingParamsButton) operationName = "Parting";
-        
-        if (!operationName.isEmpty()) {
-            emit operationParametersRequested(operationName);
-        }
-    }
-}
 
 
 void SetupConfigurationPanel::setMaterialManager(MaterialManager* materialManager)
@@ -1052,11 +1041,22 @@ void SetupConfigurationPanel::onToolSelectionRequested()
 
 void SetupConfigurationPanel::updateOperationControls()
 {
-    // Enable/disable parameter buttons based on operation checkboxes
-    m_contouringParamsButton->setEnabled(m_contouringEnabledCheck->isChecked());
-    m_threadingParamsButton->setEnabled(m_threadingEnabledCheck->isChecked());
-    m_chamferingParamsButton->setEnabled(m_chamferingEnabledCheck->isChecked());
-    m_partingParamsButton->setEnabled(m_partingEnabledCheck->isChecked());
+    // Placeholder for any additional per-operation controls
+}
+
+void SetupConfigurationPanel::focusOperationTab(const QString& operationName)
+{
+    int index = 0;
+    if (operationName.compare("Contouring", Qt::CaseInsensitive) == 0)
+        index = 0;
+    else if (operationName.compare("Threading", Qt::CaseInsensitive) == 0)
+        index = 1;
+    else if (operationName.compare("Chamfering", Qt::CaseInsensitive) == 0)
+        index = 2;
+    else if (operationName.compare("Parting", Qt::CaseInsensitive) == 0)
+        index = 3;
+    if (m_operationsTabWidget)
+        m_operationsTabWidget->setCurrentIndex(index);
 }
 
 // Utility method implementations

--- a/gui/tests/CMakeLists.txt
+++ b/gui/tests/CMakeLists.txt
@@ -60,7 +60,6 @@ qt_add_executable(gui_toolpath_generation_tests
     ${CMAKE_SOURCE_DIR}/gui/src/toolpathmanager.cpp
     ${CMAKE_SOURCE_DIR}/gui/src/toolpathtimelinewidget.cpp
     ${CMAKE_SOURCE_DIR}/gui/src/toolpathtimelineframe.cpp
-    ${CMAKE_SOURCE_DIR}/gui/src/operationparameterdialog.cpp
     ${CMAKE_SOURCE_DIR}/gui/src/workpiecemanager.cpp
     ${CMAKE_SOURCE_DIR}/gui/src/rawmaterialmanager.cpp
     ${CMAKE_SOURCE_DIR}/gui/src/chuckmanager.cpp
@@ -68,7 +67,6 @@ qt_add_executable(gui_toolpath_generation_tests
     ${CMAKE_SOURCE_DIR}/gui/include/toolpathgenerationcontroller.h
     ${CMAKE_SOURCE_DIR}/gui/include/toolpathtimelinewidget.h
     ${CMAKE_SOURCE_DIR}/gui/include/toolpathtimelineframe.h
-    ${CMAKE_SOURCE_DIR}/gui/include/operationparameterdialog.h
     ${CMAKE_SOURCE_DIR}/gui/include/workpiecemanager.h
     ${CMAKE_SOURCE_DIR}/gui/include/rawmaterialmanager.h
     ${CMAKE_SOURCE_DIR}/gui/include/chuckmanager.h
@@ -107,7 +105,6 @@ qt_add_executable(gui_toolpath_addition_tests
     ${CMAKE_SOURCE_DIR}/gui/src/toolpathmanager.cpp
     ${CMAKE_SOURCE_DIR}/gui/src/toolpathtimelinewidget.cpp
     ${CMAKE_SOURCE_DIR}/gui/src/toolpathtimelineframe.cpp
-    ${CMAKE_SOURCE_DIR}/gui/src/operationparameterdialog.cpp
     ${CMAKE_SOURCE_DIR}/gui/src/workpiecemanager.cpp
     ${CMAKE_SOURCE_DIR}/gui/src/rawmaterialmanager.cpp
     ${CMAKE_SOURCE_DIR}/gui/src/chuckmanager.cpp
@@ -115,7 +112,6 @@ qt_add_executable(gui_toolpath_addition_tests
     ${CMAKE_SOURCE_DIR}/gui/include/toolpathgenerationcontroller.h
     ${CMAKE_SOURCE_DIR}/gui/include/toolpathtimelinewidget.h
     ${CMAKE_SOURCE_DIR}/gui/include/toolpathtimelineframe.h
-    ${CMAKE_SOURCE_DIR}/gui/include/operationparameterdialog.h
     ${CMAKE_SOURCE_DIR}/gui/include/workpiecemanager.h
     ${CMAKE_SOURCE_DIR}/gui/include/rawmaterialmanager.h
     ${CMAKE_SOURCE_DIR}/gui/include/chuckmanager.h


### PR DESCRIPTION
## Summary
- remove OperationParameterDialog from build
- configure timeline click to focus operation tabs
- embed threading and chamfering parameters directly in SetupConfigurationPanel tabs
- update documentation for new workflow

## Testing
- `cmake --preset ninja-release` *(fails: Could not find toolchain file)*

------
https://chatgpt.com/codex/tasks/task_e_684f0aafcf0c83329f5773d61adc616f