### PR TITLE
Improve 3D viewer refresh on focus events

### DIFF
--- a/docs/gui/3d_viewer.md
+++ b/docs/gui/3d_viewer.md
@@ -86,7 +86,7 @@ TopoDS_Shape RawMaterialManager::createCylinderForWorkpiece(double diameter, dou
 **Solution**: Implemented robust focus and event handling:
 - Enhanced `updateView()` method with explicit context management
 - Added continuous update timer support
-- Proper focus event handling (`focusInEvent`, `focusOutEvent`)
+- Proper focus event handling (`focusInEvent`, `focusOutEvent`) with immediate redraw
 - Show/hide event management to ensure proper rendering lifecycle
 
 ```cpp
@@ -213,7 +213,7 @@ void OpenGL3DWidget::focusOutEvent(QFocusEvent *event)
 
 ### Issue: Black Screen on Focus Loss
 **Status**: ✅ Fixed in v1.1
-**Solution**: Enhanced focus event handling and continuous update support
+**Solution**: Enhanced focus event handling with immediate redraws and continuous update support
 
 ### Issue: Raw Material Not Encompassing Part
 **Status**: ✅ Fixed in v1.2

--- a/gui/src/opengl3dwidget.cpp
+++ b/gui/src/opengl3dwidget.cpp
@@ -618,11 +618,11 @@ void OpenGL3DWidget::focusInEvent(QFocusEvent *event)
     if (!m_view.IsNull() && m_isInitialized)
     {
         ensureViewerReady();
-        
-        // Additional immediate redraw for critical focus scenarios
-        QTimer::singleShot(1, this, [this]() {
-            forceRedraw();
-        });
+
+        // Trigger a direct redraw rather than relying on a timer
+        forceRedraw();
+        // Schedule an additional update to guarantee a fresh frame
+        update();
     }
 }
 
@@ -636,13 +636,12 @@ void OpenGL3DWidget::focusOutEvent(QFocusEvent *event)
     {
         // Mark for refresh when focus returns
         m_needsRefresh = true;
-        
-        // Use a very short timer to ensure context is still valid
-        QTimer::singleShot(1, this, [this]() {
-            if (!m_view.IsNull() && isVisible()) {
-                forceRedraw();
-            }
-        });
+
+        // Force an immediate redraw and schedule one more update
+        if (isVisible()) {
+            forceRedraw();
+            update();
+        }
     }
 }
 


### PR DESCRIPTION
## Summary
- refresh 3D viewer immediately on focus changes
- document fix in 3D viewer docs

## Testing
- `cmake -S . -B build` *(fails: could not find Qt6)*

------
https://chatgpt.com/codex/tasks/task_e_684f08d75e888332bf4dff10fcc017e2