### PR TITLE
Add advanced mode and parameter tables

### DIFF
--- a/docs/toolpath_workflow.md
+++ b/docs/toolpath_workflow.md
@@ -26,3 +26,9 @@ The left side of the setup tab has been simplified:
 All operation parameters are edited directly in these tabs. The previous parameter dialog window has been removed. Clicking an entry in the timeline automatically focuses the corresponding tab so you can tweak its settings.
 
 These settings are dedicated to lathe turning and are independent for every step.  The timeline at the bottom always shows the steps in the same order, but you can deactivate any of them.
+
+### Simple vs Advanced Mode
+
+The setup panel now offers a checkbox labeled **Advanced Mode**. When disabled, only the most important parameters are shown for each operation. For example, Contouring displays just the facing allowance, number of finishing passes and the final surface finish. Threading and Chamfering list the selected faces in tables where you can add or remove entries and adjust individual parameters.
+
+Enabling **Advanced Mode** reveals additional controls such as calculated cutting depth, feed rate and spindle speed. These values are pre‑filled from the material database but can be fine‑tuned manually.

--- a/gui/include/setupconfigurationpanel.h
+++ b/gui/include/setupconfigurationpanel.h
@@ -1,22 +1,23 @@
 #ifndef SETUPCONFIGURATIONPANEL_H
 #define SETUPCONFIGURATIONPANEL_H
 
-#include <QWidget>
-#include <QVBoxLayout>
-#include <QHBoxLayout>
-#include <QGroupBox>
-#include <QLabel>
-#include <QPushButton>
-#include <QLineEdit>
-#include <QComboBox>
-#include <QSpinBox>
-#include <QDoubleSpinBox>
 #include <QCheckBox>
-#include <QProgressBar>
-#include <QTextEdit>
+#include <QComboBox>
+#include <QDoubleSpinBox>
 #include <QFrame>
-#include <QTabWidget>
+#include <QGroupBox>
+#include <QHBoxLayout>
+#include <QLabel>
+#include <QLineEdit>
 #include <QMap>
+#include <QProgressBar>
+#include <QPushButton>
+#include <QSpinBox>
+#include <QTabWidget>
+#include <QTableWidget>
+#include <QTextEdit>
+#include <QVBoxLayout>
+#include <QWidget>
 
 // Forward declarations
 class QListWidget;
@@ -29,201 +30,224 @@ namespace IntuiCAM {
 namespace GUI {
 
 enum class MaterialType {
-    Aluminum6061,
-    Aluminum7075,
-    Steel1018,
-    Steel4140,
-    StainlessSteel316,
-    StainlessSteel304,
-    Brass360,
-    Bronze,
-    Titanium,
-    Plastic_ABS,
-    Plastic_Delrin,
-    Custom
+  Aluminum6061,
+  Aluminum7075,
+  Steel1018,
+  Steel4140,
+  StainlessSteel316,
+  StainlessSteel304,
+  Brass360,
+  Bronze,
+  Titanium,
+  Plastic_ABS,
+  Plastic_Delrin,
+  Custom
 };
 
 enum class SurfaceFinish {
-    Rough_32Ra,     // 32 μm Ra (rough machining)
-    Medium_16Ra,    // 16 μm Ra (standard machining)
-    Fine_8Ra,       // 8 μm Ra (finish machining)
-    Smooth_4Ra,     // 4 μm Ra (precision machining)
-    Polish_2Ra,     // 2 μm Ra (polished)
-    Mirror_1Ra      // 1 μm Ra (mirror finish)
+  Rough_32Ra,  // 32 μm Ra (rough machining)
+  Medium_16Ra, // 16 μm Ra (standard machining)
+  Fine_8Ra,    // 8 μm Ra (finish machining)
+  Smooth_4Ra,  // 4 μm Ra (precision machining)
+  Polish_2Ra,  // 2 μm Ra (polished)
+  Mirror_1Ra   // 1 μm Ra (mirror finish)
 };
 
 struct OperationConfig {
-    bool enabled;
-    QString name;
-    QString description;
-    QStringList parameters;
+  bool enabled;
+  QString name;
+  QString description;
+  QStringList parameters;
 };
 
-class SetupConfigurationPanel : public QWidget
-{
-    Q_OBJECT
+class SetupConfigurationPanel : public QWidget {
+  Q_OBJECT
 
 public:
-    explicit SetupConfigurationPanel(QWidget *parent = nullptr);
-    ~SetupConfigurationPanel();
+  explicit SetupConfigurationPanel(QWidget *parent = nullptr);
+  ~SetupConfigurationPanel();
 
-    // Getters
-    QString getStepFilePath() const;
-    MaterialType getMaterialType() const;
-    double getRawDiameter() const;
-    double getDistanceToChuck() const;
-    bool isOrientationFlipped() const;
-    double getFacingAllowance() const;
-    double getRoughingAllowance() const;
-    double getFinishingAllowance() const;
-    double getPartingWidth() const;
-    SurfaceFinish getSurfaceFinish() const;
-    double getTolerance() const;
-    bool isOperationEnabled(const QString& operationName) const;
-    OperationConfig getOperationConfig(const QString& operationName) const;
+  // Getters
+  QString getStepFilePath() const;
+  MaterialType getMaterialType() const;
+  double getRawDiameter() const;
+  double getDistanceToChuck() const;
+  bool isOrientationFlipped() const;
+  double getFacingAllowance() const;
+  double getRoughingAllowance() const;
+  double getFinishingAllowance() const;
+  double getPartingWidth() const;
+  SurfaceFinish getSurfaceFinish() const;
+  double getTolerance() const;
+  bool isOperationEnabled(const QString &operationName) const;
+  OperationConfig getOperationConfig(const QString &operationName) const;
 
-    // Setters
-    void setStepFilePath(const QString& path);
-    void setMaterialType(MaterialType type);
-    void setRawDiameter(double diameter);
-    void setDistanceToChuck(double distance);
-    void setOrientationFlipped(bool flipped);
-    void updateRawMaterialLength(double length);
-    void setFacingAllowance(double allowance);
-    void setRoughingAllowance(double allowance);
-    void setFinishingAllowance(double allowance);
-    void setPartingWidth(double width);
-    void setSurfaceFinish(SurfaceFinish finish);
-    void setTolerance(double tolerance);
-    void setOperationEnabled(const QString& operationName, bool enabled);
-    void updateAxisInfo(const QString& info);
+  // Setters
+  void setStepFilePath(const QString &path);
+  void setMaterialType(MaterialType type);
+  void setRawDiameter(double diameter);
+  void setDistanceToChuck(double distance);
+  void setOrientationFlipped(bool flipped);
+  void updateRawMaterialLength(double length);
+  void setFacingAllowance(double allowance);
+  void setRoughingAllowance(double allowance);
+  void setFinishingAllowance(double allowance);
+  void setPartingWidth(double width);
+  void setSurfaceFinish(SurfaceFinish finish);
+  void setTolerance(double tolerance);
+  void setOperationEnabled(const QString &operationName, bool enabled);
+  void updateAxisInfo(const QString &info);
 
-    // Material and Tool Management
-    void setMaterialManager(MaterialManager* materialManager);
-    void setToolManager(ToolManager* toolManager);
-    QString getSelectedMaterialName() const;
-    QStringList getRecommendedTools() const;
-    void updateMaterialProperties();
-    void updateToolRecommendations();
-    void focusOperationTab(const QString& operationName);
+  // Material and Tool Management
+  void setMaterialManager(MaterialManager *materialManager);
+  void setToolManager(ToolManager *toolManager);
+  QString getSelectedMaterialName() const;
+  QStringList getRecommendedTools() const;
+  void updateMaterialProperties();
+  void updateToolRecommendations();
+  void focusOperationTab(const QString &operationName);
 
-    // Utility methods
-    static QString materialTypeToString(MaterialType type);
-    static MaterialType stringToMaterialType(const QString& typeStr);
-    static QString surfaceFinishToString(SurfaceFinish finish);
-    static SurfaceFinish stringToSurfaceFinish(const QString& finishStr);
+  // Utility methods
+  static QString materialTypeToString(MaterialType type);
+  static MaterialType stringToMaterialType(const QString &typeStr);
+  static QString surfaceFinishToString(SurfaceFinish finish);
+  static SurfaceFinish stringToSurfaceFinish(const QString &finishStr);
 
 signals:
-    void configurationChanged();
-    void stepFileSelected(const QString& filePath);
-    void materialTypeChanged(MaterialType type);
-    void rawMaterialDiameterChanged(double diameter);
-    void distanceToChuckChanged(double distance);
-    void orientationFlipped(bool flipped);
-    void manualAxisSelectionRequested();
-    void operationToggled(const QString& operationName, bool enabled);
-    void automaticToolpathGenerationRequested();
-    void materialSelectionChanged(const QString& materialName);
-    void toolRecommendationsUpdated(const QStringList& toolIds);
+  void configurationChanged();
+  void stepFileSelected(const QString &filePath);
+  void materialTypeChanged(MaterialType type);
+  void rawMaterialDiameterChanged(double diameter);
+  void distanceToChuckChanged(double distance);
+  void orientationFlipped(bool flipped);
+  void manualAxisSelectionRequested();
+  void operationToggled(const QString &operationName, bool enabled);
+  void automaticToolpathGenerationRequested();
+  void materialSelectionChanged(const QString &materialName);
+  void toolRecommendationsUpdated(const QStringList &toolIds);
 
 public slots:
-    void onBrowseStepFile();
-    void onConfigurationChanged();
-    void onManualAxisSelectionClicked();
-    void onOperationToggled();
-    void onMaterialChanged();
-    void onToolSelectionRequested();
+  void onBrowseStepFile();
+  void onConfigurationChanged();
+  void onManualAxisSelectionClicked();
+  void onOperationToggled();
+  void onMaterialChanged();
+  void onToolSelectionRequested();
 
 private:
-    void setupUI();
-    void setupPartTab();
-    void setupMachiningTab(); // now sets up operation-specific tabs
-    void setupConnections();
-    void applyTabStyling();
-    void updateOperationControls();
+  void setupUI();
+  void setupPartTab();
+  void setupMachiningTab(); // now sets up operation-specific tabs
+  void setupConnections();
+  void applyTabStyling();
+  void updateOperationControls();
+  void updateAdvancedMode();
 
-    // Main layout and tabs
-    QVBoxLayout* m_mainLayout;
-    QWidget* m_partTab;
-    QTabWidget* m_operationsTabWidget;
-    QWidget* m_contouringTab;
-    QWidget* m_threadingTab;
-    QWidget* m_chamferingTab;
-    QWidget* m_partingTab;
+  // Main layout and tabs
+  QVBoxLayout *m_mainLayout;
+  QWidget *m_partTab;
+  QTabWidget *m_operationsTabWidget;
+  QWidget *m_contouringTab;
+  QWidget *m_threadingTab;
+  QWidget *m_chamferingTab;
+  QWidget *m_partingTab;
 
-    // Part Tab Components (Part Setup + Material Settings)
-    QGroupBox* m_partSetupGroup;
-    QVBoxLayout* m_partSetupLayout;
-    QHBoxLayout* m_stepFileLayout;
-    QLineEdit* m_stepFileEdit;
-    QPushButton* m_browseButton;
-    QPushButton* m_manualAxisButton;
-    QLabel* m_axisInfoLabel;
-    
-    // Part positioning controls
-    QHBoxLayout* m_distanceLayout;
-    QLabel* m_distanceLabel;
-    QSlider* m_distanceSlider;
-    QDoubleSpinBox* m_distanceSpinBox;
-    QCheckBox* m_flipOrientationCheckBox;
+  // Part Tab Components (Part Setup + Material Settings)
+  QGroupBox *m_partSetupGroup;
+  QVBoxLayout *m_partSetupLayout;
+  QHBoxLayout *m_stepFileLayout;
+  QLineEdit *m_stepFileEdit;
+  QPushButton *m_browseButton;
+  QPushButton *m_manualAxisButton;
+  QLabel *m_axisInfoLabel;
 
-    QGroupBox* m_materialGroup;
-    QVBoxLayout* m_materialLayout;
-    QHBoxLayout* m_materialTypeLayout;
-    QLabel* m_materialTypeLabel;
-    QComboBox* m_materialTypeCombo;
-    QHBoxLayout* m_rawDiameterLayout;
-    QLabel* m_rawDiameterLabel;
-    QDoubleSpinBox* m_rawDiameterSpin;
-    QLabel* m_rawLengthLabel; // Now just a label showing auto-calculated length
+  // Part positioning controls
+  QHBoxLayout *m_distanceLayout;
+  QLabel *m_distanceLabel;
+  QSlider *m_distanceSlider;
+  QDoubleSpinBox *m_distanceSpinBox;
+  QCheckBox *m_flipOrientationCheckBox;
 
-    // Machining Tab Components (Machining Parameters + Operations + Quality)
-    QGroupBox* m_machiningParamsGroup;
-    QVBoxLayout* m_machiningParamsLayout;
-    QHBoxLayout* m_facingAllowanceLayout;
-    QLabel* m_facingAllowanceLabel;
-    QDoubleSpinBox* m_facingAllowanceSpin;
-    QHBoxLayout* m_roughingAllowanceLayout;
-    QLabel* m_roughingAllowanceLabel;
-    QDoubleSpinBox* m_roughingAllowanceSpin;
-    QHBoxLayout* m_finishingAllowanceLayout;
-    QLabel* m_finishingAllowanceLabel;
-    QDoubleSpinBox* m_finishingAllowanceSpin;
-    QHBoxLayout* m_partingWidthLayout;
-    QLabel* m_partingWidthLabel;
-    QDoubleSpinBox* m_partingWidthSpin;
+  QGroupBox *m_materialGroup;
+  QVBoxLayout *m_materialLayout;
+  QHBoxLayout *m_materialTypeLayout;
+  QLabel *m_materialTypeLabel;
+  QComboBox *m_materialTypeCombo;
+  QHBoxLayout *m_rawDiameterLayout;
+  QLabel *m_rawDiameterLabel;
+  QDoubleSpinBox *m_rawDiameterSpin;
+  QLabel *m_rawLengthLabel; // Now just a label showing auto-calculated length
 
-    // Legacy placeholders to preserve binary compatibility
-    QGroupBox* m_operationsGroup;
-    QVBoxLayout* m_operationsLayout;
-    QCheckBox* m_contouringEnabledCheck;
-    QCheckBox* m_threadingEnabledCheck;
-    QDoubleSpinBox* m_threadPitchSpin;
-    QCheckBox* m_chamferingEnabledCheck;
-    QDoubleSpinBox* m_chamferSizeSpin;
-    QCheckBox* m_partingEnabledCheck;
+  // Machining Tab Components (Machining Parameters + Operations + Quality)
+  QGroupBox *m_machiningParamsGroup;
+  QVBoxLayout *m_machiningParamsLayout;
+  QHBoxLayout *m_facingAllowanceLayout;
+  QLabel *m_facingAllowanceLabel;
+  QDoubleSpinBox *m_facingAllowanceSpin;
+  QHBoxLayout *m_roughingAllowanceLayout;
+  QLabel *m_roughingAllowanceLabel;
+  QDoubleSpinBox *m_roughingAllowanceSpin;
+  QHBoxLayout *m_finishingAllowanceLayout;
+  QLabel *m_finishingAllowanceLabel;
+  QDoubleSpinBox *m_finishingAllowanceSpin;
+  QHBoxLayout *m_partingWidthLayout;
+  QLabel *m_partingWidthLabel;
+  QDoubleSpinBox *m_partingWidthSpin;
 
-    QGroupBox* m_qualityGroup;
-    QVBoxLayout* m_qualityLayout;
-    QHBoxLayout* m_surfaceFinishLayout;
-    QLabel* m_surfaceFinishLabel;
-    QComboBox* m_surfaceFinishCombo;
-    QHBoxLayout* m_toleranceLayout;
-    QLabel* m_toleranceLabel;
-    QDoubleSpinBox* m_toleranceSpin;
+  // Advanced cutting parameter widgets
+  QGroupBox *m_contourAdvancedGroup;
+  QDoubleSpinBox *m_contourDepthSpin;
+  QDoubleSpinBox *m_contourFeedSpin;
+  QDoubleSpinBox *m_contourSpeedSpin;
 
+  // Advanced mode toggle
+  QCheckBox *m_advancedModeCheck;
 
-    // Material and Tool Management Integration
-    MaterialManager* m_materialManager;
-    ToolManager* m_toolManager;
-    QMap<QString, QListWidget*> m_operationToolLists;
+  // Simplified parameters
+  QSpinBox *m_finishingPassesSpin;
 
-    // Enhanced material display
-    QLabel* m_materialPropertiesLabel;
-    QPushButton* m_materialDetailsButton;
+  // Threading face table
+  QTableWidget *m_threadFacesTable;
+  QPushButton *m_addThreadFaceButton;
+  QPushButton *m_removeThreadFaceButton;
+
+  // Chamfering face table
+  QTableWidget *m_chamferFacesTable;
+  QPushButton *m_addChamferFaceButton;
+  QPushButton *m_removeChamferFaceButton;
+  QDoubleSpinBox *m_extraChamferStockSpin;
+  QDoubleSpinBox *m_chamferDiameterLeaveSpin;
+
+  // Legacy placeholders to preserve binary compatibility
+  QGroupBox *m_operationsGroup;
+  QVBoxLayout *m_operationsLayout;
+  QCheckBox *m_contouringEnabledCheck;
+  QCheckBox *m_threadingEnabledCheck;
+  QDoubleSpinBox *m_threadPitchSpin;
+  QCheckBox *m_chamferingEnabledCheck;
+  QDoubleSpinBox *m_chamferSizeSpin;
+  QCheckBox *m_partingEnabledCheck;
+
+  QGroupBox *m_qualityGroup;
+  QVBoxLayout *m_qualityLayout;
+  QHBoxLayout *m_surfaceFinishLayout;
+  QLabel *m_surfaceFinishLabel;
+  QComboBox *m_surfaceFinishCombo;
+  QHBoxLayout *m_toleranceLayout;
+  QLabel *m_toleranceLabel;
+  QDoubleSpinBox *m_toleranceSpin;
+
+  // Material and Tool Management Integration
+  MaterialManager *m_materialManager;
+  ToolManager *m_toolManager;
+  QMap<QString, QListWidget *> m_operationToolLists;
+
+  // Enhanced material display
+  QLabel *m_materialPropertiesLabel;
+  QPushButton *m_materialDetailsButton;
 };
 
 } // namespace GUI
 } // namespace IntuiCAM
 
-#endif // SETUPCONFIGURATIONPANEL_H 
+#endif // SETUPCONFIGURATIONPANEL_H

--- a/gui/src/setupconfigurationpanel.cpp
+++ b/gui/src/setupconfigurationpanel.cpp
@@ -2,27 +2,30 @@
 #include "materialmanager.h"
 #include "toolmanager.h"
 #include <QApplication>
-#include <QFileDialog>
-#include <QMessageBox>
-#include <QSplitter>
-#include <QHeaderView>
-#include <QDir>
-#include <QSlider>
 #include <QCheckBox>
-#include <QLabel>
-#include <QVBoxLayout>
-#include <QHBoxLayout>
-#include <QGroupBox>
-#include <QPushButton>
 #include <QComboBox>
+#include <QDir>
 #include <QDoubleSpinBox>
-#include <QTabWidget>
+#include <QFileDialog>
+#include <QFormLayout>
+#include <QGroupBox>
+#include <QHBoxLayout>
+#include <QHeaderView>
+#include <QLabel>
 #include <QLineEdit>
-#include <QProgressBar>
 #include <QListWidget>
 #include <QListWidgetItem>
+#include <QMessageBox>
+#include <QProgressBar>
+#include <QPushButton>
 #include <QScrollArea>
 #include <QSignalBlocker>
+#include <QSlider>
+#include <QSpinBox>
+#include <QSplitter>
+#include <QTabWidget>
+#include <QTableWidget>
+#include <QVBoxLayout>
 
 namespace IntuiCAM {
 namespace GUI {
@@ -30,567 +33,664 @@ namespace GUI {
 using namespace IntuiCAM::GUI;
 
 // Define the static const members
-const QStringList MATERIAL_NAMES = {
-    "Aluminum 6061-T6",
-    "Aluminum 7075-T6",
-    "Steel 1018",
-    "Steel 4140",
-    "Stainless Steel 316",
-    "Stainless Steel 304",
-    "Brass C360",
-    "Bronze",
-    "Titanium Grade 5",
-    "Plastic - ABS",
-    "Plastic - Delrin (POM)",
-    "Custom Material"
-};
+const QStringList MATERIAL_NAMES = {"Aluminum 6061-T6",
+                                    "Aluminum 7075-T6",
+                                    "Steel 1018",
+                                    "Steel 4140",
+                                    "Stainless Steel 316",
+                                    "Stainless Steel 304",
+                                    "Brass C360",
+                                    "Bronze",
+                                    "Titanium Grade 5",
+                                    "Plastic - ABS",
+                                    "Plastic - Delrin (POM)",
+                                    "Custom Material"};
 
 const QStringList SURFACE_FINISH_NAMES = {
-    "Rough (32 μm Ra)",
-    "Medium (16 μm Ra)",
-    "Fine (8 μm Ra)",
-    "Smooth (4 μm Ra)",
-    "Polished (2 μm Ra)",
-    "Mirror (1 μm Ra)"
-};
+    "Rough (32 μm Ra)", "Medium (16 μm Ra)",  "Fine (8 μm Ra)",
+    "Smooth (4 μm Ra)", "Polished (2 μm Ra)", "Mirror (1 μm Ra)"};
 
-const QStringList OPERATION_ORDER = {
-    "Contouring",
-    "Threading",
-    "Chamfering",
-    "Parting"
-};
+const QStringList OPERATION_ORDER = {"Contouring", "Threading", "Chamfering",
+                                     "Parting"};
 
 SetupConfigurationPanel::SetupConfigurationPanel(QWidget *parent)
-    : QWidget(parent)
-    , m_mainLayout(nullptr)
-    , m_partTab(nullptr)
-    , m_operationsTabWidget(nullptr)
-    , m_contouringTab(nullptr)
-    , m_threadingTab(nullptr)
-    , m_chamferingTab(nullptr)
-    , m_partingTab(nullptr)
-    , m_materialManager(nullptr)
-    , m_toolManager(nullptr)
-    , m_materialPropertiesLabel(nullptr)
-    , m_contouringEnabledCheck(nullptr)
-    , m_contouringParamsButton(nullptr) /*deprecated*/
-    , m_threadingEnabledCheck(nullptr)
-    , m_threadingParamsButton(nullptr) /*deprecated*/
-    , m_chamferingEnabledCheck(nullptr)
-    , m_chamferingParamsButton(nullptr) /*deprecated*/
-    , m_partingEnabledCheck(nullptr)
-    , m_partingParamsButton(nullptr) /*deprecated*/
-{
-    setupUI();
-    setupConnections();
-    applyTabStyling();
+    : QWidget(parent), m_mainLayout(nullptr), m_partTab(nullptr),
+      m_operationsTabWidget(nullptr), m_contouringTab(nullptr),
+      m_threadingTab(nullptr), m_chamferingTab(nullptr), m_partingTab(nullptr),
+      m_materialManager(nullptr), m_toolManager(nullptr),
+      m_materialPropertiesLabel(nullptr), m_contouringEnabledCheck(nullptr),
+      m_contouringParamsButton(nullptr) /*deprecated*/
+      ,
+      m_threadingEnabledCheck(nullptr),
+      m_threadingParamsButton(nullptr) /*deprecated*/
+      ,
+      m_chamferingEnabledCheck(nullptr),
+      m_chamferingParamsButton(nullptr) /*deprecated*/
+      ,
+      m_partingEnabledCheck(nullptr),
+      m_partingParamsButton(nullptr) /*deprecated*/
+      ,
+      m_advancedModeCheck(nullptr), m_finishingPassesSpin(nullptr),
+      m_threadFacesTable(nullptr), m_addThreadFaceButton(nullptr),
+      m_removeThreadFaceButton(nullptr), m_chamferFacesTable(nullptr),
+      m_addChamferFaceButton(nullptr), m_removeChamferFaceButton(nullptr),
+      m_extraChamferStockSpin(nullptr), m_chamferDiameterLeaveSpin(nullptr) {
+  setupUI();
+  setupConnections();
+  applyTabStyling();
 }
 
-SetupConfigurationPanel::~SetupConfigurationPanel()
-{
-    // Qt handles cleanup automatically
+SetupConfigurationPanel::~SetupConfigurationPanel() {
+  // Qt handles cleanup automatically
 }
 
-void SetupConfigurationPanel::setupUI()
-{
-    m_mainLayout = new QVBoxLayout(this);
-    m_mainLayout->setSpacing(8);
-    m_mainLayout->setContentsMargins(8, 8, 8, 8);
+void SetupConfigurationPanel::setupUI() {
+  m_mainLayout = new QVBoxLayout(this);
+  m_mainLayout->setSpacing(8);
+  m_mainLayout->setContentsMargins(8, 8, 8, 8);
 
-    // Create top part setup section
-    m_partTab = new QWidget();
-    setupPartTab();
-    m_mainLayout->addWidget(m_partTab);
+  // Create top part setup section
+  m_partTab = new QWidget();
+  setupPartTab();
+  m_mainLayout->addWidget(m_partTab);
 
-    // Create operations tab widget
-    m_operationsTabWidget = new QTabWidget();
-    m_operationsTabWidget->setTabPosition(QTabWidget::North);
-    m_operationsTabWidget->setDocumentMode(true);
+  // Advanced mode toggle
+  QHBoxLayout *advLayout = new QHBoxLayout();
+  m_advancedModeCheck = new QCheckBox("Advanced Mode");
+  advLayout->addWidget(m_advancedModeCheck);
+  advLayout->addStretch();
+  m_mainLayout->addLayout(advLayout);
+  connect(m_advancedModeCheck, &QCheckBox::toggled, this,
+          &SetupConfigurationPanel::updateAdvancedMode);
 
-    // Create operation tabs (content widgets)
-    m_contouringTab = new QWidget();
-    m_threadingTab = new QWidget();
-    m_chamferingTab = new QWidget();
-    m_partingTab = new QWidget();
+  // Create operations tab widget
+  m_operationsTabWidget = new QTabWidget();
+  m_operationsTabWidget->setTabPosition(QTabWidget::North);
+  m_operationsTabWidget->setDocumentMode(true);
 
-    // Wrap each tab in a scroll area to allow scrolling when content exceeds
-    // the available space. The scroll areas themselves are local to this
-    // method, but the inner tab widgets are stored in member variables for
-    // later access.
-    QScrollArea* contourScroll = new QScrollArea();
-    contourScroll->setWidgetResizable(true);
-    contourScroll->setFrameShape(QFrame::NoFrame);
-    contourScroll->setWidget(m_contouringTab);
+  // Create operation tabs (content widgets)
+  m_contouringTab = new QWidget();
+  m_threadingTab = new QWidget();
+  m_chamferingTab = new QWidget();
+  m_partingTab = new QWidget();
 
-    QScrollArea* threadingScroll = new QScrollArea();
-    threadingScroll->setWidgetResizable(true);
-    threadingScroll->setFrameShape(QFrame::NoFrame);
-    threadingScroll->setWidget(m_threadingTab);
+  // Wrap each tab in a scroll area to allow scrolling when content exceeds
+  // the available space. The scroll areas themselves are local to this
+  // method, but the inner tab widgets are stored in member variables for
+  // later access.
+  QScrollArea *contourScroll = new QScrollArea();
+  contourScroll->setWidgetResizable(true);
+  contourScroll->setFrameShape(QFrame::NoFrame);
+  contourScroll->setWidget(m_contouringTab);
 
-    QScrollArea* chamferScroll = new QScrollArea();
-    chamferScroll->setWidgetResizable(true);
-    chamferScroll->setFrameShape(QFrame::NoFrame);
-    chamferScroll->setWidget(m_chamferingTab);
+  QScrollArea *threadingScroll = new QScrollArea();
+  threadingScroll->setWidgetResizable(true);
+  threadingScroll->setFrameShape(QFrame::NoFrame);
+  threadingScroll->setWidget(m_threadingTab);
 
-    QScrollArea* partingScroll = new QScrollArea();
-    partingScroll->setWidgetResizable(true);
-    partingScroll->setFrameShape(QFrame::NoFrame);
-    partingScroll->setWidget(m_partingTab);
+  QScrollArea *chamferScroll = new QScrollArea();
+  chamferScroll->setWidgetResizable(true);
+  chamferScroll->setFrameShape(QFrame::NoFrame);
+  chamferScroll->setWidget(m_chamferingTab);
 
-    // Setup individual operation tabs
-    setupMachiningTab();
+  QScrollArea *partingScroll = new QScrollArea();
+  partingScroll->setWidgetResizable(true);
+  partingScroll->setFrameShape(QFrame::NoFrame);
+  partingScroll->setWidget(m_partingTab);
 
-    // Add tabs to widget using the scroll areas created above
-    m_operationsTabWidget->addTab(contourScroll, "Contouring");
-    m_operationsTabWidget->addTab(threadingScroll, "Threading");
-    m_operationsTabWidget->addTab(chamferScroll, "Chamfering");
-    m_operationsTabWidget->addTab(partingScroll, "Parting");
+  // Setup individual operation tabs
+  setupMachiningTab();
 
-    // Add operations tab widget to main layout
-    m_mainLayout->addWidget(m_operationsTabWidget);
+  // Add tabs to widget using the scroll areas created above
+  m_operationsTabWidget->addTab(contourScroll, "Contouring");
+  m_operationsTabWidget->addTab(threadingScroll, "Threading");
+  m_operationsTabWidget->addTab(chamferScroll, "Chamfering");
+  m_operationsTabWidget->addTab(partingScroll, "Parting");
 
-    
+  // Add operations tab widget to main layout
+  m_mainLayout->addWidget(m_operationsTabWidget);
 }
 
-void SetupConfigurationPanel::setupPartTab()
-{
-    QVBoxLayout* partTabLayout = new QVBoxLayout(m_partTab);
-    partTabLayout->setContentsMargins(12, 12, 12, 12);
-    partTabLayout->setSpacing(16);
+void SetupConfigurationPanel::setupPartTab() {
+  QVBoxLayout *partTabLayout = new QVBoxLayout(m_partTab);
+  partTabLayout->setContentsMargins(12, 12, 12, 12);
+  partTabLayout->setSpacing(16);
 
-    // Part Setup Group
-    m_partSetupGroup = new QGroupBox("Part Setup");
-    m_partSetupLayout = new QVBoxLayout(m_partSetupGroup);
-    m_partSetupLayout->setSpacing(8);
+  // Part Setup Group
+  m_partSetupGroup = new QGroupBox("Part Setup");
+  m_partSetupLayout = new QVBoxLayout(m_partSetupGroup);
+  m_partSetupLayout->setSpacing(8);
 
-    // STEP file selection
-    m_stepFileLayout = new QHBoxLayout();
-    QLabel* stepFileLabel = new QLabel("STEP File:");
-    stepFileLabel->setMinimumWidth(120);
-    m_stepFileEdit = new QLineEdit();
-    m_stepFileEdit->setPlaceholderText("Select STEP file...");
-    m_stepFileEdit->setReadOnly(true);
-    m_browseButton = new QPushButton("Browse...");
-    m_browseButton->setMaximumWidth(80);
-    
-    m_stepFileLayout->addWidget(stepFileLabel);
-    m_stepFileLayout->addWidget(m_stepFileEdit);
-    m_stepFileLayout->addWidget(m_browseButton);
-    m_partSetupLayout->addLayout(m_stepFileLayout);
+  // STEP file selection
+  m_stepFileLayout = new QHBoxLayout();
+  QLabel *stepFileLabel = new QLabel("STEP File:");
+  stepFileLabel->setMinimumWidth(120);
+  m_stepFileEdit = new QLineEdit();
+  m_stepFileEdit->setPlaceholderText("Select STEP file...");
+  m_stepFileEdit->setReadOnly(true);
+  m_browseButton = new QPushButton("Browse...");
+  m_browseButton->setMaximumWidth(80);
 
-    // Manual rotational axis selection
-    m_manualAxisButton = new QPushButton("Select Rotational Axis from 3D View");
-    m_manualAxisButton->setMinimumHeight(32);
-    m_manualAxisButton->setStyleSheet(
-        "QPushButton {"
-        "  background-color: #2196F3;"
-        "  color: white;"
-        "  border: none;"
-        "  border-radius: 4px;"
-        "  font-weight: bold;"
-        "}"
-        "QPushButton:hover {"
-        "  background-color: #1976D2;"
-        "}"
-        "QPushButton:pressed {"
-        "  background-color: #1565C0;"
-        "}"
-    );
-    
-    m_axisInfoLabel = new QLabel("Click the button above, then select a cylindrical surface or circular edge in the 3D view");
-    m_axisInfoLabel->setStyleSheet("color: #666; font-size: 11px;");
-    m_axisInfoLabel->setWordWrap(true);
-    
-    m_partSetupLayout->addWidget(m_manualAxisButton);
-    m_partSetupLayout->addWidget(m_axisInfoLabel);
-    
-    // Part positioning controls
-    m_distanceLayout = new QHBoxLayout();
-    m_distanceLabel = new QLabel("Distance to Chuck:");
-    m_distanceLabel->setMinimumWidth(120);
-    m_distanceSlider = new QSlider(Qt::Horizontal);
-    m_distanceSlider->setRange(0, 100);
-    m_distanceSlider->setValue(25);
-    m_distanceSpinBox = new QDoubleSpinBox();
-    m_distanceSpinBox->setRange(0.0, 100.0);
-    m_distanceSpinBox->setValue(25.0);
-    m_distanceSpinBox->setSuffix(" mm");
-    m_distanceSpinBox->setDecimals(1);
-    m_distanceSpinBox->setMaximumWidth(80);
-    
-    m_distanceLayout->addWidget(m_distanceLabel);
-    m_distanceLayout->addWidget(m_distanceSlider);
-    m_distanceLayout->addWidget(m_distanceSpinBox);
-    m_partSetupLayout->addLayout(m_distanceLayout);
-    
-    // Orientation flip checkbox
-    m_flipOrientationCheckBox = new QCheckBox("Flip Part Orientation (180°)");
-    m_flipOrientationCheckBox->setChecked(false);
-    m_partSetupLayout->addWidget(m_flipOrientationCheckBox);
+  m_stepFileLayout->addWidget(stepFileLabel);
+  m_stepFileLayout->addWidget(m_stepFileEdit);
+  m_stepFileLayout->addWidget(m_browseButton);
+  m_partSetupLayout->addLayout(m_stepFileLayout);
 
-    partTabLayout->addWidget(m_partSetupGroup);
+  // Manual rotational axis selection
+  m_manualAxisButton = new QPushButton("Select Rotational Axis from 3D View");
+  m_manualAxisButton->setMinimumHeight(32);
+  m_manualAxisButton->setStyleSheet("QPushButton {"
+                                    "  background-color: #2196F3;"
+                                    "  color: white;"
+                                    "  border: none;"
+                                    "  border-radius: 4px;"
+                                    "  font-weight: bold;"
+                                    "}"
+                                    "QPushButton:hover {"
+                                    "  background-color: #1976D2;"
+                                    "}"
+                                    "QPushButton:pressed {"
+                                    "  background-color: #1565C0;"
+                                    "}");
 
-    // Material Settings Group
-    m_materialGroup = new QGroupBox("Material Settings");
-    m_materialLayout = new QVBoxLayout(m_materialGroup);
-    m_materialLayout->setSpacing(8);
+  m_axisInfoLabel =
+      new QLabel("Click the button above, then select a cylindrical surface or "
+                 "circular edge in the 3D view");
+  m_axisInfoLabel->setStyleSheet("color: #666; font-size: 11px;");
+  m_axisInfoLabel->setWordWrap(true);
 
-    // Material type
-    m_materialTypeLayout = new QHBoxLayout();
-    m_materialTypeLabel = new QLabel("Material Type:");
-    m_materialTypeLabel->setMinimumWidth(120);
-    m_materialTypeCombo = new QComboBox();
-    m_materialTypeCombo->addItems(MATERIAL_NAMES);
-    m_materialTypeCombo->setCurrentText("Aluminum 6061-T6");
-    
-    m_materialTypeLayout->addWidget(m_materialTypeLabel);
-    m_materialTypeLayout->addWidget(m_materialTypeCombo);
-    m_materialTypeLayout->addStretch();
-    m_materialLayout->addLayout(m_materialTypeLayout);
+  m_partSetupLayout->addWidget(m_manualAxisButton);
+  m_partSetupLayout->addWidget(m_axisInfoLabel);
 
-    // Raw material diameter
-    m_rawDiameterLayout = new QHBoxLayout();
-    m_rawDiameterLabel = new QLabel("Raw Diameter:");
-    m_rawDiameterLabel->setMinimumWidth(120);
-    m_rawDiameterSpin = new QDoubleSpinBox();
-    m_rawDiameterSpin->setRange(5.0, 500.0);
-    m_rawDiameterSpin->setValue(50.0);
-    m_rawDiameterSpin->setSuffix(" mm");
-    m_rawDiameterSpin->setDecimals(1);
-    
-    m_rawDiameterLayout->addWidget(m_rawDiameterLabel);
-    m_rawDiameterLayout->addWidget(m_rawDiameterSpin);
-    m_rawDiameterLayout->addStretch();
-    m_materialLayout->addLayout(m_rawDiameterLayout);
+  // Part positioning controls
+  m_distanceLayout = new QHBoxLayout();
+  m_distanceLabel = new QLabel("Distance to Chuck:");
+  m_distanceLabel->setMinimumWidth(120);
+  m_distanceSlider = new QSlider(Qt::Horizontal);
+  m_distanceSlider->setRange(0, 100);
+  m_distanceSlider->setValue(25);
+  m_distanceSpinBox = new QDoubleSpinBox();
+  m_distanceSpinBox->setRange(0.0, 100.0);
+  m_distanceSpinBox->setValue(25.0);
+  m_distanceSpinBox->setSuffix(" mm");
+  m_distanceSpinBox->setDecimals(1);
+  m_distanceSpinBox->setMaximumWidth(80);
 
-    // Raw material length (auto-calculated, display only)
-    m_rawLengthLabel = new QLabel("Raw Length: Auto-calculated");
-    m_rawLengthLabel->setStyleSheet("color: #666; font-size: 11px;");
-    m_materialLayout->addWidget(m_rawLengthLabel);
+  m_distanceLayout->addWidget(m_distanceLabel);
+  m_distanceLayout->addWidget(m_distanceSlider);
+  m_distanceLayout->addWidget(m_distanceSpinBox);
+  m_partSetupLayout->addLayout(m_distanceLayout);
 
-    // Material properties display
-    m_materialPropertiesLabel = new QLabel("Material properties will be shown here");
-    m_materialPropertiesLabel->setStyleSheet("color: #666; font-size: 11px; padding: 8px; background: #f5f5f5; border-radius: 4px;");
-    m_materialPropertiesLabel->setWordWrap(true);
-    m_materialLayout->addWidget(m_materialPropertiesLabel);
+  // Orientation flip checkbox
+  m_flipOrientationCheckBox = new QCheckBox("Flip Part Orientation (180°)");
+  m_flipOrientationCheckBox->setChecked(false);
+  m_partSetupLayout->addWidget(m_flipOrientationCheckBox);
 
-    // Material details button
-    m_materialDetailsButton = new QPushButton("Material Details & Cutting Parameters");
-    m_materialDetailsButton->setMaximumHeight(28);
-    m_materialDetailsButton->setStyleSheet(
-        "QPushButton {"
-        "  background-color: #4CAF50;"
-        "  color: white;"
-        "  border: none;"
-        "  border-radius: 4px;"
-        "  font-size: 11px;"
-        "}"
-        "QPushButton:hover {"
-        "  background-color: #45a049;"
-        "}"
-    );
-    m_materialLayout->addWidget(m_materialDetailsButton);
+  partTabLayout->addWidget(m_partSetupGroup);
 
-    partTabLayout->addWidget(m_materialGroup);
+  // Material Settings Group
+  m_materialGroup = new QGroupBox("Material Settings");
+  m_materialLayout = new QVBoxLayout(m_materialGroup);
+  m_materialLayout->setSpacing(8);
 
-    partTabLayout->addStretch();
+  // Material type
+  m_materialTypeLayout = new QHBoxLayout();
+  m_materialTypeLabel = new QLabel("Material Type:");
+  m_materialTypeLabel->setMinimumWidth(120);
+  m_materialTypeCombo = new QComboBox();
+  m_materialTypeCombo->addItems(MATERIAL_NAMES);
+  m_materialTypeCombo->setCurrentText("Aluminum 6061-T6");
+
+  m_materialTypeLayout->addWidget(m_materialTypeLabel);
+  m_materialTypeLayout->addWidget(m_materialTypeCombo);
+  m_materialTypeLayout->addStretch();
+  m_materialLayout->addLayout(m_materialTypeLayout);
+
+  // Raw material diameter
+  m_rawDiameterLayout = new QHBoxLayout();
+  m_rawDiameterLabel = new QLabel("Raw Diameter:");
+  m_rawDiameterLabel->setMinimumWidth(120);
+  m_rawDiameterSpin = new QDoubleSpinBox();
+  m_rawDiameterSpin->setRange(5.0, 500.0);
+  m_rawDiameterSpin->setValue(50.0);
+  m_rawDiameterSpin->setSuffix(" mm");
+  m_rawDiameterSpin->setDecimals(1);
+
+  m_rawDiameterLayout->addWidget(m_rawDiameterLabel);
+  m_rawDiameterLayout->addWidget(m_rawDiameterSpin);
+  m_rawDiameterLayout->addStretch();
+  m_materialLayout->addLayout(m_rawDiameterLayout);
+
+  // Raw material length (auto-calculated, display only)
+  m_rawLengthLabel = new QLabel("Raw Length: Auto-calculated");
+  m_rawLengthLabel->setStyleSheet("color: #666; font-size: 11px;");
+  m_materialLayout->addWidget(m_rawLengthLabel);
+
+  // Material properties display
+  m_materialPropertiesLabel =
+      new QLabel("Material properties will be shown here");
+  m_materialPropertiesLabel->setStyleSheet(
+      "color: #666; font-size: 11px; padding: 8px; background: #f5f5f5; "
+      "border-radius: 4px;");
+  m_materialPropertiesLabel->setWordWrap(true);
+  m_materialLayout->addWidget(m_materialPropertiesLabel);
+
+  // Material details button
+  m_materialDetailsButton =
+      new QPushButton("Material Details & Cutting Parameters");
+  m_materialDetailsButton->setMaximumHeight(28);
+  m_materialDetailsButton->setStyleSheet("QPushButton {"
+                                         "  background-color: #4CAF50;"
+                                         "  color: white;"
+                                         "  border: none;"
+                                         "  border-radius: 4px;"
+                                         "  font-size: 11px;"
+                                         "}"
+                                         "QPushButton:hover {"
+                                         "  background-color: #45a049;"
+                                         "}");
+  m_materialLayout->addWidget(m_materialDetailsButton);
+
+  partTabLayout->addWidget(m_materialGroup);
+
+  partTabLayout->addStretch();
 }
 
-void SetupConfigurationPanel::setupMachiningTab()
-{
-    // --- Contouring Tab ---
-    QVBoxLayout* contourLayout = new QVBoxLayout(m_contouringTab);
-    contourLayout->setContentsMargins(12, 12, 12, 12);
-    contourLayout->setSpacing(16);
+void SetupConfigurationPanel::setupMachiningTab() {
+  // --- Contouring Tab ---
+  QVBoxLayout *contourLayout = new QVBoxLayout(m_contouringTab);
+  contourLayout->setContentsMargins(12, 12, 12, 12);
+  contourLayout->setSpacing(16);
 
-    QHBoxLayout* contourEnableLayout = new QHBoxLayout();
-    m_contouringEnabledCheck = new QCheckBox("Enable Contouring");
-    contourEnableLayout->addWidget(m_contouringEnabledCheck);
-    contourEnableLayout->addStretch();
-    contourLayout->addLayout(contourEnableLayout);
+  QHBoxLayout *contourEnableLayout = new QHBoxLayout();
+  m_contouringEnabledCheck = new QCheckBox("Enable Contouring");
+  contourEnableLayout->addWidget(m_contouringEnabledCheck);
+  contourEnableLayout->addStretch();
+  contourLayout->addLayout(contourEnableLayout);
 
-    m_machiningParamsGroup = new QGroupBox("Machining Parameters");
-    m_machiningParamsLayout = new QVBoxLayout(m_machiningParamsGroup);
-    m_machiningParamsLayout->setSpacing(8);
+  m_machiningParamsGroup = new QGroupBox("Machining Parameters");
+  m_machiningParamsLayout = new QVBoxLayout(m_machiningParamsGroup);
+  m_machiningParamsLayout->setSpacing(8);
 
-    // Facing allowance
-    m_facingAllowanceLayout = new QHBoxLayout();
-    m_facingAllowanceLabel = new QLabel("Facing Allowance:");
-    m_facingAllowanceLabel->setMinimumWidth(140);
-    m_facingAllowanceSpin = new QDoubleSpinBox();
-    m_facingAllowanceSpin->setRange(0.0, 50.0);
-    m_facingAllowanceSpin->setValue(10.0);
-    m_facingAllowanceSpin->setSuffix(" mm");
-    m_facingAllowanceSpin->setDecimals(1);
-    
-    m_facingAllowanceLayout->addWidget(m_facingAllowanceLabel);
-    m_facingAllowanceLayout->addWidget(m_facingAllowanceSpin);
-    m_facingAllowanceLayout->addStretch();
-    m_machiningParamsLayout->addLayout(m_facingAllowanceLayout);
+  // Facing allowance
+  m_facingAllowanceLayout = new QHBoxLayout();
+  m_facingAllowanceLabel = new QLabel("Facing Allowance:");
+  m_facingAllowanceLabel->setMinimumWidth(140);
+  m_facingAllowanceSpin = new QDoubleSpinBox();
+  m_facingAllowanceSpin->setRange(0.0, 50.0);
+  m_facingAllowanceSpin->setValue(10.0);
+  m_facingAllowanceSpin->setSuffix(" mm");
+  m_facingAllowanceSpin->setDecimals(1);
 
-    // Roughing allowance
-    m_roughingAllowanceLayout = new QHBoxLayout();
-    m_roughingAllowanceLabel = new QLabel("Roughing Allowance:");
-    m_roughingAllowanceLabel->setMinimumWidth(140);
-    m_roughingAllowanceSpin = new QDoubleSpinBox();
-    m_roughingAllowanceSpin->setRange(0.0, 5.0);
-    m_roughingAllowanceSpin->setValue(1.0);
-    m_roughingAllowanceSpin->setSuffix(" mm");
-    m_roughingAllowanceSpin->setDecimals(2);
-    
-    m_roughingAllowanceLayout->addWidget(m_roughingAllowanceLabel);
-    m_roughingAllowanceLayout->addWidget(m_roughingAllowanceSpin);
-    m_roughingAllowanceLayout->addStretch();
-    m_machiningParamsLayout->addLayout(m_roughingAllowanceLayout);
+  m_facingAllowanceLayout->addWidget(m_facingAllowanceLabel);
+  m_facingAllowanceLayout->addWidget(m_facingAllowanceSpin);
+  m_facingAllowanceLayout->addStretch();
+  m_machiningParamsLayout->addLayout(m_facingAllowanceLayout);
 
-    // Finishing allowance
-    m_finishingAllowanceLayout = new QHBoxLayout();
-    m_finishingAllowanceLabel = new QLabel("Finishing Allowance:");
-    m_finishingAllowanceLabel->setMinimumWidth(140);
-    m_finishingAllowanceSpin = new QDoubleSpinBox();
-    m_finishingAllowanceSpin->setRange(0.0, 2.0);
-    m_finishingAllowanceSpin->setValue(0.2);
-    m_finishingAllowanceSpin->setSuffix(" mm");
-    m_finishingAllowanceSpin->setDecimals(2);
-    
-    m_finishingAllowanceLayout->addWidget(m_finishingAllowanceLabel);
-    m_finishingAllowanceLayout->addWidget(m_finishingAllowanceSpin);
-    m_finishingAllowanceLayout->addStretch();
-    m_machiningParamsLayout->addLayout(m_finishingAllowanceLayout);
+  // Roughing allowance
+  m_roughingAllowanceLayout = new QHBoxLayout();
+  m_roughingAllowanceLabel = new QLabel("Roughing Allowance:");
+  m_roughingAllowanceLabel->setMinimumWidth(140);
+  m_roughingAllowanceSpin = new QDoubleSpinBox();
+  m_roughingAllowanceSpin->setRange(0.0, 5.0);
+  m_roughingAllowanceSpin->setValue(1.0);
+  m_roughingAllowanceSpin->setSuffix(" mm");
+  m_roughingAllowanceSpin->setDecimals(2);
 
-    // Parting width
-    m_partingWidthLayout = new QHBoxLayout();
-    m_partingWidthLabel = new QLabel("Parting Width:");
-    m_partingWidthLabel->setMinimumWidth(140);
-    m_partingWidthSpin = new QDoubleSpinBox();
-    m_partingWidthSpin->setRange(1.0, 5.0);
-    m_partingWidthSpin->setValue(3.0);
-    m_partingWidthSpin->setSuffix(" mm");
-    m_partingWidthSpin->setDecimals(1);
-    
-    m_partingWidthLayout->addWidget(m_partingWidthLabel);
-    m_partingWidthLayout->addWidget(m_partingWidthSpin);
-    m_partingWidthLayout->addStretch();
-    m_machiningParamsLayout->addLayout(m_partingWidthLayout);
+  m_roughingAllowanceLayout->addWidget(m_roughingAllowanceLabel);
+  m_roughingAllowanceLayout->addWidget(m_roughingAllowanceSpin);
+  m_roughingAllowanceLayout->addStretch();
+  m_machiningParamsLayout->addLayout(m_roughingAllowanceLayout);
 
-    contourLayout->addWidget(m_machiningParamsGroup);
+  // Finishing allowance
+  m_finishingAllowanceLayout = new QHBoxLayout();
+  m_finishingAllowanceLabel = new QLabel("Finishing Allowance:");
+  m_finishingAllowanceLabel->setMinimumWidth(140);
+  m_finishingAllowanceSpin = new QDoubleSpinBox();
+  m_finishingAllowanceSpin->setRange(0.0, 2.0);
+  m_finishingAllowanceSpin->setValue(0.2);
+  m_finishingAllowanceSpin->setSuffix(" mm");
+  m_finishingAllowanceSpin->setDecimals(2);
 
-    // Quality Group
-    m_qualityGroup = new QGroupBox("Quality Settings");
-    m_qualityLayout = new QVBoxLayout(m_qualityGroup);
-    m_qualityLayout->setSpacing(8);
+  m_finishingAllowanceLayout->addWidget(m_finishingAllowanceLabel);
+  m_finishingAllowanceLayout->addWidget(m_finishingAllowanceSpin);
+  m_finishingAllowanceLayout->addStretch();
+  m_machiningParamsLayout->addLayout(m_finishingAllowanceLayout);
 
-    // Surface finish
-    m_surfaceFinishLayout = new QHBoxLayout();
-    m_surfaceFinishLabel = new QLabel("Surface Finish:");
-    m_surfaceFinishLabel->setMinimumWidth(140);
-    m_surfaceFinishCombo = new QComboBox();
-    
-    // Add surface finish options
-    QStringList SURFACE_FINISH_NAMES = {
-        "Rough (32 μm Ra)",
-        "Medium (16 μm Ra)",
-        "Fine (8 μm Ra)",
-        "Smooth (4 μm Ra)",
-        "Polished (2 μm Ra)",
-        "Mirror (1 μm Ra)"
-    };
-    
-    m_surfaceFinishCombo->addItems(SURFACE_FINISH_NAMES);
-    m_surfaceFinishCombo->setCurrentText("Medium (16 μm Ra)");
-    
-    m_surfaceFinishLayout->addWidget(m_surfaceFinishLabel);
-    m_surfaceFinishLayout->addWidget(m_surfaceFinishCombo);
-    m_surfaceFinishLayout->addStretch();
-    m_qualityLayout->addLayout(m_surfaceFinishLayout);
+  // Number of finishing passes
+  QHBoxLayout *finishPassLayout = new QHBoxLayout();
+  QLabel *finishPassLabel = new QLabel("Finishing Passes:");
+  finishPassLabel->setMinimumWidth(140);
+  m_finishingPassesSpin = new QSpinBox();
+  m_finishingPassesSpin->setRange(1, 10);
+  m_finishingPassesSpin->setValue(1);
+  finishPassLayout->addWidget(finishPassLabel);
+  finishPassLayout->addWidget(m_finishingPassesSpin);
+  finishPassLayout->addStretch();
+  m_machiningParamsLayout->addLayout(finishPassLayout);
 
-    // Tolerance
-    m_toleranceLayout = new QHBoxLayout();
-    m_toleranceLabel = new QLabel("Tolerance:");
-    m_toleranceLabel->setMinimumWidth(140);
-    m_toleranceSpin = new QDoubleSpinBox();
-    m_toleranceSpin->setRange(0.001, 1.0);
-    m_toleranceSpin->setValue(0.1);
-    m_toleranceSpin->setSuffix(" mm");
-    m_toleranceSpin->setDecimals(3);
-    
-    m_toleranceLayout->addWidget(m_toleranceLabel);
-    m_toleranceLayout->addWidget(m_toleranceSpin);
-    m_toleranceLayout->addStretch();
-    m_qualityLayout->addLayout(m_toleranceLayout);
+  // Parting width
+  m_partingWidthLayout = new QHBoxLayout();
+  m_partingWidthLabel = new QLabel("Parting Width:");
+  m_partingWidthLabel->setMinimumWidth(140);
+  m_partingWidthSpin = new QDoubleSpinBox();
+  m_partingWidthSpin->setRange(1.0, 5.0);
+  m_partingWidthSpin->setValue(3.0);
+  m_partingWidthSpin->setSuffix(" mm");
+  m_partingWidthSpin->setDecimals(1);
 
-    contourLayout->addWidget(m_qualityGroup);
+  m_partingWidthLayout->addWidget(m_partingWidthLabel);
+  m_partingWidthLayout->addWidget(m_partingWidthSpin);
+  m_partingWidthLayout->addStretch();
+  m_machiningParamsLayout->addLayout(m_partingWidthLayout);
 
-    QGroupBox* contourToolsGroup = new QGroupBox("Recommended Tools");
-    QVBoxLayout* contourToolsLayout = new QVBoxLayout(contourToolsGroup);
-    QListWidget* contourToolsList = new QListWidget();
-    contourToolsLayout->addWidget(contourToolsList);
-    contourLayout->addWidget(contourToolsGroup);
-    m_operationToolLists.insert("contouring", contourToolsList);
+  contourLayout->addWidget(m_machiningParamsGroup);
 
-    contourLayout->addStretch();
+  // Quality Group
+  m_qualityGroup = new QGroupBox("Quality Settings");
+  m_qualityLayout = new QVBoxLayout(m_qualityGroup);
+  m_qualityLayout->setSpacing(8);
 
-    // --- Threading Tab ---
-    QVBoxLayout* threadingLayout = new QVBoxLayout(m_threadingTab);
-    threadingLayout->setContentsMargins(12, 12, 12, 12);
-    threadingLayout->setSpacing(16);
-    QHBoxLayout* threadEnableLayout = new QHBoxLayout();
-    m_threadingEnabledCheck = new QCheckBox("Enable Threading");
-    threadEnableLayout->addWidget(m_threadingEnabledCheck);
-    threadEnableLayout->addStretch();
-    threadingLayout->addLayout(threadEnableLayout);
-    QLabel* threadingInfo = new QLabel("Select faces to thread in the 3D view.");
-    threadingInfo->setWordWrap(true);
-    threadingLayout->addWidget(threadingInfo);
+  // Surface finish
+  m_surfaceFinishLayout = new QHBoxLayout();
+  m_surfaceFinishLabel = new QLabel("Surface Finish:");
+  m_surfaceFinishLabel->setMinimumWidth(140);
+  m_surfaceFinishCombo = new QComboBox();
 
-    QHBoxLayout* pitchLayout = new QHBoxLayout();
-    QLabel* pitchLabel = new QLabel("Thread Pitch:");
-    pitchLabel->setMinimumWidth(140);
-    m_threadPitchSpin = new QDoubleSpinBox();
-    m_threadPitchSpin->setRange(0.1, 10.0);
-    m_threadPitchSpin->setValue(1.0);
-    m_threadPitchSpin->setDecimals(2);
-    m_threadPitchSpin->setSuffix(" mm");
-    pitchLayout->addWidget(pitchLabel);
-    pitchLayout->addWidget(m_threadPitchSpin);
-    pitchLayout->addStretch();
-    threadingLayout->addLayout(pitchLayout);
+  // Add surface finish options
+  QStringList SURFACE_FINISH_NAMES = {"Rough (32 μm Ra)",   "Medium (16 μm Ra)",
+                                      "Fine (8 μm Ra)",     "Smooth (4 μm Ra)",
+                                      "Polished (2 μm Ra)", "Mirror (1 μm Ra)"};
 
-    QGroupBox* threadingToolsGroup = new QGroupBox("Recommended Tools");
-    QVBoxLayout* threadingToolsLayout = new QVBoxLayout(threadingToolsGroup);
-    QListWidget* threadingToolsList = new QListWidget();
-    threadingToolsLayout->addWidget(threadingToolsList);
-    threadingLayout->addWidget(threadingToolsGroup);
-    m_operationToolLists.insert("threading", threadingToolsList);
+  m_surfaceFinishCombo->addItems(SURFACE_FINISH_NAMES);
+  m_surfaceFinishCombo->setCurrentText("Medium (16 μm Ra)");
 
-    threadingLayout->addStretch();
+  m_surfaceFinishLayout->addWidget(m_surfaceFinishLabel);
+  m_surfaceFinishLayout->addWidget(m_surfaceFinishCombo);
+  m_surfaceFinishLayout->addStretch();
+  m_qualityLayout->addLayout(m_surfaceFinishLayout);
 
-    // --- Chamfering Tab ---
-    QVBoxLayout* chamferLayout = new QVBoxLayout(m_chamferingTab);
-    chamferLayout->setContentsMargins(12, 12, 12, 12);
-    chamferLayout->setSpacing(16);
-    QHBoxLayout* chamferEnableLayout = new QHBoxLayout();
-    m_chamferingEnabledCheck = new QCheckBox("Enable Chamfering");
-    chamferEnableLayout->addWidget(m_chamferingEnabledCheck);
-    chamferEnableLayout->addStretch();
-    chamferLayout->addLayout(chamferEnableLayout);
-    QLabel* chamferInfo = new QLabel("Select edges to chamfer in the 3D view.");
-    chamferInfo->setWordWrap(true);
-    chamferLayout->addWidget(chamferInfo);
+  // Tolerance
+  m_toleranceLayout = new QHBoxLayout();
+  m_toleranceLabel = new QLabel("Tolerance:");
+  m_toleranceLabel->setMinimumWidth(140);
+  m_toleranceSpin = new QDoubleSpinBox();
+  m_toleranceSpin->setRange(0.001, 1.0);
+  m_toleranceSpin->setValue(0.1);
+  m_toleranceSpin->setSuffix(" mm");
+  m_toleranceSpin->setDecimals(3);
 
-    QHBoxLayout* chamferSizeLayout = new QHBoxLayout();
-    QLabel* chamferSizeLabel = new QLabel("Chamfer Size:");
-    chamferSizeLabel->setMinimumWidth(140);
-    m_chamferSizeSpin = new QDoubleSpinBox();
-    m_chamferSizeSpin->setRange(0.1, 5.0);
-    m_chamferSizeSpin->setValue(0.5);
-    m_chamferSizeSpin->setDecimals(2);
-    m_chamferSizeSpin->setSuffix(" mm");
-    chamferSizeLayout->addWidget(chamferSizeLabel);
-    chamferSizeLayout->addWidget(m_chamferSizeSpin);
-    chamferSizeLayout->addStretch();
-    chamferLayout->addLayout(chamferSizeLayout);
+  m_toleranceLayout->addWidget(m_toleranceLabel);
+  m_toleranceLayout->addWidget(m_toleranceSpin);
+  m_toleranceLayout->addStretch();
+  m_qualityLayout->addLayout(m_toleranceLayout);
 
-    QGroupBox* chamferToolsGroup = new QGroupBox("Recommended Tools");
-    QVBoxLayout* chamferToolsLayout = new QVBoxLayout(chamferToolsGroup);
-    QListWidget* chamferToolsList = new QListWidget();
-    chamferToolsLayout->addWidget(chamferToolsList);
-    chamferLayout->addWidget(chamferToolsGroup);
-    m_operationToolLists.insert("chamfering", chamferToolsList);
+  contourLayout->addWidget(m_qualityGroup);
 
-    chamferLayout->addStretch();
+  QGroupBox *contourToolsGroup = new QGroupBox("Recommended Tools");
+  QVBoxLayout *contourToolsLayout = new QVBoxLayout(contourToolsGroup);
+  QListWidget *contourToolsList = new QListWidget();
+  contourToolsLayout->addWidget(contourToolsList);
+  contourLayout->addWidget(contourToolsGroup);
+  m_operationToolLists.insert("contouring", contourToolsList);
 
-    // --- Parting Tab ---
-    QVBoxLayout* partLayout = new QVBoxLayout(m_partingTab);
-    partLayout->setContentsMargins(12, 12, 12, 12);
-    partLayout->setSpacing(16);
-    QHBoxLayout* partEnableLayout = new QHBoxLayout();
-    m_partingEnabledCheck = new QCheckBox("Enable Parting");
-    partEnableLayout->addWidget(m_partingEnabledCheck);
-    partEnableLayout->addStretch();
-    partLayout->addLayout(partEnableLayout);
-    m_partingWidthLayout = new QHBoxLayout();
-    m_partingWidthLabel = new QLabel("Parting Width:");
-    m_partingWidthLabel->setMinimumWidth(140);
-    m_partingWidthSpin = new QDoubleSpinBox();
-    m_partingWidthSpin->setRange(1.0, 5.0);
-    m_partingWidthSpin->setValue(3.0);
-    m_partingWidthSpin->setSuffix(" mm");
-    m_partingWidthSpin->setDecimals(1);
-    m_partingWidthLayout->addWidget(m_partingWidthLabel);
-    m_partingWidthLayout->addWidget(m_partingWidthSpin);
-    m_partingWidthLayout->addStretch();
-    partLayout->addLayout(m_partingWidthLayout);
+  // Advanced cutting parameters
+  m_contourAdvancedGroup = new QGroupBox("Advanced Cutting");
+  QFormLayout *contourAdvLayout = new QFormLayout(m_contourAdvancedGroup);
+  m_contourDepthSpin = new QDoubleSpinBox();
+  m_contourDepthSpin->setRange(0.01, 10.0);
+  m_contourDepthSpin->setSuffix(" mm");
+  m_contourFeedSpin = new QDoubleSpinBox();
+  m_contourFeedSpin->setRange(0.1, 1000.0);
+  m_contourFeedSpin->setSuffix(" mm/rev");
+  m_contourSpeedSpin = new QDoubleSpinBox();
+  m_contourSpeedSpin->setRange(10.0, 10000.0);
+  m_contourSpeedSpin->setSuffix(" RPM");
+  contourAdvLayout->addRow("Depth of Cut:", m_contourDepthSpin);
+  contourAdvLayout->addRow("Feed Rate:", m_contourFeedSpin);
+  contourAdvLayout->addRow("Spindle Speed:", m_contourSpeedSpin);
+  contourLayout->addWidget(m_contourAdvancedGroup);
 
-    QGroupBox* partingToolsGroup = new QGroupBox("Recommended Tools");
-    QVBoxLayout* partingToolsLayout = new QVBoxLayout(partingToolsGroup);
-    QListWidget* partingToolsList = new QListWidget();
-    partingToolsLayout->addWidget(partingToolsList);
-    partLayout->addWidget(partingToolsGroup);
-    m_operationToolLists.insert("parting", partingToolsList);
+  contourLayout->addStretch();
 
-    partLayout->addStretch();
+  // --- Threading Tab ---
+  QVBoxLayout *threadingLayout = new QVBoxLayout(m_threadingTab);
+  threadingLayout->setContentsMargins(12, 12, 12, 12);
+  threadingLayout->setSpacing(16);
+  QHBoxLayout *threadEnableLayout = new QHBoxLayout();
+  m_threadingEnabledCheck = new QCheckBox("Enable Threading");
+  threadEnableLayout->addWidget(m_threadingEnabledCheck);
+  threadEnableLayout->addStretch();
+  threadingLayout->addLayout(threadEnableLayout);
+  QLabel *threadingInfo = new QLabel("Select faces to thread in the 3D view.");
+  threadingInfo->setWordWrap(true);
+  threadingLayout->addWidget(threadingInfo);
+
+  QHBoxLayout *pitchLayout = new QHBoxLayout();
+  QLabel *pitchLabel = new QLabel("Thread Pitch:");
+  pitchLabel->setMinimumWidth(140);
+  m_threadPitchSpin = new QDoubleSpinBox();
+  m_threadPitchSpin->setRange(0.1, 10.0);
+  m_threadPitchSpin->setValue(1.0);
+  m_threadPitchSpin->setDecimals(2);
+  m_threadPitchSpin->setSuffix(" mm");
+  pitchLayout->addWidget(pitchLabel);
+  pitchLayout->addWidget(m_threadPitchSpin);
+  pitchLayout->addStretch();
+  threadingLayout->addLayout(pitchLayout);
+
+  m_threadFacesTable = new QTableWidget(0, 3);
+  QStringList threadHeaders{"Face", "Preset", "Pitch"};
+  m_threadFacesTable->setHorizontalHeaderLabels(threadHeaders);
+  m_threadFacesTable->horizontalHeader()->setStretchLastSection(true);
+  threadingLayout->addWidget(m_threadFacesTable);
+
+  QHBoxLayout *threadFaceBtnLayout = new QHBoxLayout();
+  m_addThreadFaceButton = new QPushButton("Add Face");
+  m_removeThreadFaceButton = new QPushButton("Remove Face");
+  threadFaceBtnLayout->addWidget(m_addThreadFaceButton);
+  threadFaceBtnLayout->addWidget(m_removeThreadFaceButton);
+  threadFaceBtnLayout->addStretch();
+  threadingLayout->addLayout(threadFaceBtnLayout);
+
+  QGroupBox *threadingToolsGroup = new QGroupBox("Recommended Tools");
+  QVBoxLayout *threadingToolsLayout = new QVBoxLayout(threadingToolsGroup);
+  QListWidget *threadingToolsList = new QListWidget();
+  threadingToolsLayout->addWidget(threadingToolsList);
+  threadingLayout->addWidget(threadingToolsGroup);
+  m_operationToolLists.insert("threading", threadingToolsList);
+
+  threadingLayout->addStretch();
+
+  // --- Chamfering Tab ---
+  QVBoxLayout *chamferLayout = new QVBoxLayout(m_chamferingTab);
+  chamferLayout->setContentsMargins(12, 12, 12, 12);
+  chamferLayout->setSpacing(16);
+  QHBoxLayout *chamferEnableLayout = new QHBoxLayout();
+  m_chamferingEnabledCheck = new QCheckBox("Enable Chamfering");
+  chamferEnableLayout->addWidget(m_chamferingEnabledCheck);
+  chamferEnableLayout->addStretch();
+  chamferLayout->addLayout(chamferEnableLayout);
+  QLabel *chamferInfo = new QLabel("Select edges to chamfer in the 3D view.");
+  chamferInfo->setWordWrap(true);
+  chamferLayout->addWidget(chamferInfo);
+
+  QHBoxLayout *chamferSizeLayout = new QHBoxLayout();
+  QLabel *chamferSizeLabel = new QLabel("Chamfer Size:");
+  chamferSizeLabel->setMinimumWidth(140);
+  m_chamferSizeSpin = new QDoubleSpinBox();
+  m_chamferSizeSpin->setRange(0.1, 5.0);
+  m_chamferSizeSpin->setValue(0.5);
+  m_chamferSizeSpin->setDecimals(2);
+  m_chamferSizeSpin->setSuffix(" mm");
+  chamferSizeLayout->addWidget(chamferSizeLabel);
+  chamferSizeLayout->addWidget(m_chamferSizeSpin);
+  chamferSizeLayout->addStretch();
+  chamferLayout->addLayout(chamferSizeLayout);
+
+  m_chamferFacesTable = new QTableWidget(0, 4);
+  QStringList chamferHeaders{"Face", "Symmetric", "Value A", "Value B"};
+  m_chamferFacesTable->setHorizontalHeaderLabels(chamferHeaders);
+  m_chamferFacesTable->horizontalHeader()->setStretchLastSection(true);
+  chamferLayout->addWidget(m_chamferFacesTable);
+
+  QHBoxLayout *chamferBtnLayout = new QHBoxLayout();
+  m_addChamferFaceButton = new QPushButton("Add Face");
+  m_removeChamferFaceButton = new QPushButton("Remove Face");
+  chamferBtnLayout->addWidget(m_addChamferFaceButton);
+  chamferBtnLayout->addWidget(m_removeChamferFaceButton);
+  chamferBtnLayout->addStretch();
+  chamferLayout->addLayout(chamferBtnLayout);
+
+  QHBoxLayout *extraStockLayout = new QHBoxLayout();
+  QLabel *extraStockLabel = new QLabel("Extra Cleanup Stock:");
+  extraStockLabel->setMinimumWidth(140);
+  m_extraChamferStockSpin = new QDoubleSpinBox();
+  m_extraChamferStockSpin->setRange(0.0, 2.0);
+  m_extraChamferStockSpin->setValue(0.0);
+  m_extraChamferStockSpin->setSuffix(" mm");
+  extraStockLayout->addWidget(extraStockLabel);
+  extraStockLayout->addWidget(m_extraChamferStockSpin);
+  extraStockLayout->addStretch();
+  chamferLayout->addLayout(extraStockLayout);
+
+  QHBoxLayout *diamLeaveLayout = new QHBoxLayout();
+  QLabel *diamLeaveLabel = new QLabel("Diameter Leave:");
+  diamLeaveLabel->setMinimumWidth(140);
+  m_chamferDiameterLeaveSpin = new QDoubleSpinBox();
+  m_chamferDiameterLeaveSpin->setRange(0.0, 5.0);
+  m_chamferDiameterLeaveSpin->setValue(0.0);
+  m_chamferDiameterLeaveSpin->setSuffix(" mm");
+  diamLeaveLayout->addWidget(diamLeaveLabel);
+  diamLeaveLayout->addWidget(m_chamferDiameterLeaveSpin);
+  diamLeaveLayout->addStretch();
+  chamferLayout->addLayout(diamLeaveLayout);
+
+  QGroupBox *chamferToolsGroup = new QGroupBox("Recommended Tools");
+  QVBoxLayout *chamferToolsLayout = new QVBoxLayout(chamferToolsGroup);
+  QListWidget *chamferToolsList = new QListWidget();
+  chamferToolsLayout->addWidget(chamferToolsList);
+  chamferLayout->addWidget(chamferToolsGroup);
+  m_operationToolLists.insert("chamfering", chamferToolsList);
+
+  chamferLayout->addStretch();
+
+  // --- Parting Tab ---
+  QVBoxLayout *partLayout = new QVBoxLayout(m_partingTab);
+  partLayout->setContentsMargins(12, 12, 12, 12);
+  partLayout->setSpacing(16);
+  QHBoxLayout *partEnableLayout = new QHBoxLayout();
+  m_partingEnabledCheck = new QCheckBox("Enable Parting");
+  partEnableLayout->addWidget(m_partingEnabledCheck);
+  partEnableLayout->addStretch();
+  partLayout->addLayout(partEnableLayout);
+  m_partingWidthLayout = new QHBoxLayout();
+  m_partingWidthLabel = new QLabel("Parting Width:");
+  m_partingWidthLabel->setMinimumWidth(140);
+  m_partingWidthSpin = new QDoubleSpinBox();
+  m_partingWidthSpin->setRange(1.0, 5.0);
+  m_partingWidthSpin->setValue(3.0);
+  m_partingWidthSpin->setSuffix(" mm");
+  m_partingWidthSpin->setDecimals(1);
+  m_partingWidthLayout->addWidget(m_partingWidthLabel);
+  m_partingWidthLayout->addWidget(m_partingWidthSpin);
+  m_partingWidthLayout->addStretch();
+  partLayout->addLayout(m_partingWidthLayout);
+
+  QGroupBox *partingToolsGroup = new QGroupBox("Recommended Tools");
+  QVBoxLayout *partingToolsLayout = new QVBoxLayout(partingToolsGroup);
+  QListWidget *partingToolsList = new QListWidget();
+  partingToolsLayout->addWidget(partingToolsList);
+  partLayout->addWidget(partingToolsGroup);
+  m_operationToolLists.insert("parting", partingToolsList);
+
+  partLayout->addStretch();
 }
 
-void SetupConfigurationPanel::setupConnections()
-{
-    // Part tab connections
-    connect(m_browseButton, &QPushButton::clicked, this, &SetupConfigurationPanel::onBrowseStepFile);
-    connect(m_manualAxisButton, &QPushButton::clicked, this, &SetupConfigurationPanel::onManualAxisSelectionClicked);
-    connect(m_materialTypeCombo, QOverload<int>::of(&QComboBox::currentIndexChanged), this, &SetupConfigurationPanel::onMaterialChanged);
-    
-    // Material and tool management connections
-    if (m_materialDetailsButton) {
-        connect(m_materialDetailsButton, &QPushButton::clicked, this, &SetupConfigurationPanel::onToolSelectionRequested);
-    }
-    connect(m_rawDiameterSpin, QOverload<double>::of(&QDoubleSpinBox::valueChanged), this, &SetupConfigurationPanel::onConfigurationChanged);
-    
-    // Part positioning connections
-    connect(m_distanceSlider, &QSlider::valueChanged, this, [this](int value) {
-        m_distanceSpinBox->setValue(static_cast<double>(value));
-    });
-    connect(m_distanceSpinBox, QOverload<double>::of(&QDoubleSpinBox::valueChanged), this, [this](double value) {
-        m_distanceSlider->setValue(static_cast<int>(value));
-        emit distanceToChuckChanged(value);
-        emit configurationChanged();
-    });
-    connect(m_flipOrientationCheckBox, &QCheckBox::toggled, this, [this](bool checked) {
-        emit orientationFlipped(checked);
-        emit configurationChanged();
-    });
+void SetupConfigurationPanel::setupConnections() {
+  // Part tab connections
+  connect(m_browseButton, &QPushButton::clicked, this,
+          &SetupConfigurationPanel::onBrowseStepFile);
+  connect(m_manualAxisButton, &QPushButton::clicked, this,
+          &SetupConfigurationPanel::onManualAxisSelectionClicked);
+  connect(m_materialTypeCombo,
+          QOverload<int>::of(&QComboBox::currentIndexChanged), this,
+          &SetupConfigurationPanel::onMaterialChanged);
 
-    // Machining tab connections
-    connect(m_facingAllowanceSpin, QOverload<double>::of(&QDoubleSpinBox::valueChanged), this, &SetupConfigurationPanel::onConfigurationChanged);
-    connect(m_roughingAllowanceSpin, QOverload<double>::of(&QDoubleSpinBox::valueChanged), this, &SetupConfigurationPanel::onConfigurationChanged);
-    connect(m_finishingAllowanceSpin, QOverload<double>::of(&QDoubleSpinBox::valueChanged), this, &SetupConfigurationPanel::onConfigurationChanged);
-    connect(m_partingWidthSpin, QOverload<double>::of(&QDoubleSpinBox::valueChanged), this, &SetupConfigurationPanel::onConfigurationChanged);
-    connect(m_threadPitchSpin, QOverload<double>::of(&QDoubleSpinBox::valueChanged), this, &SetupConfigurationPanel::onConfigurationChanged);
-    connect(m_chamferSizeSpin, QOverload<double>::of(&QDoubleSpinBox::valueChanged), this, &SetupConfigurationPanel::onConfigurationChanged);
-    
-    connect(m_surfaceFinishCombo, QOverload<int>::of(&QComboBox::currentIndexChanged), this, &SetupConfigurationPanel::onConfigurationChanged);
-    connect(m_toleranceSpin, QOverload<double>::of(&QDoubleSpinBox::valueChanged), this, &SetupConfigurationPanel::onConfigurationChanged);
+  // Material and tool management connections
+  if (m_materialDetailsButton) {
+    connect(m_materialDetailsButton, &QPushButton::clicked, this,
+            &SetupConfigurationPanel::onToolSelectionRequested);
+  }
+  connect(m_rawDiameterSpin,
+          QOverload<double>::of(&QDoubleSpinBox::valueChanged), this,
+          &SetupConfigurationPanel::onConfigurationChanged);
 
-    // Operation controls - only connect if widgets exist
-    if (m_contouringEnabledCheck) {
-        connect(m_contouringEnabledCheck, &QCheckBox::toggled, this, &SetupConfigurationPanel::onOperationToggled);
-    }
-    if (m_threadingEnabledCheck) {
-        connect(m_threadingEnabledCheck, &QCheckBox::toggled, this, &SetupConfigurationPanel::onOperationToggled);
-    }
-    if (m_chamferingEnabledCheck) {
-        connect(m_chamferingEnabledCheck, &QCheckBox::toggled, this, &SetupConfigurationPanel::onOperationToggled);
-    }
-    if (m_partingEnabledCheck) {
-        connect(m_partingEnabledCheck, &QCheckBox::toggled, this, &SetupConfigurationPanel::onOperationToggled);
-    }
+  // Part positioning connections
+  connect(m_distanceSlider, &QSlider::valueChanged, this, [this](int value) {
+    m_distanceSpinBox->setValue(static_cast<double>(value));
+  });
+  connect(m_distanceSpinBox,
+          QOverload<double>::of(&QDoubleSpinBox::valueChanged), this,
+          [this](double value) {
+            m_distanceSlider->setValue(static_cast<int>(value));
+            emit distanceToChuckChanged(value);
+            emit configurationChanged();
+          });
+  connect(m_flipOrientationCheckBox, &QCheckBox::toggled, this,
+          [this](bool checked) {
+            emit orientationFlipped(checked);
+            emit configurationChanged();
+          });
 
+  // Machining tab connections
+  connect(m_facingAllowanceSpin,
+          QOverload<double>::of(&QDoubleSpinBox::valueChanged), this,
+          &SetupConfigurationPanel::onConfigurationChanged);
+  connect(m_roughingAllowanceSpin,
+          QOverload<double>::of(&QDoubleSpinBox::valueChanged), this,
+          &SetupConfigurationPanel::onConfigurationChanged);
+  connect(m_finishingAllowanceSpin,
+          QOverload<double>::of(&QDoubleSpinBox::valueChanged), this,
+          &SetupConfigurationPanel::onConfigurationChanged);
+  connect(m_partingWidthSpin,
+          QOverload<double>::of(&QDoubleSpinBox::valueChanged), this,
+          &SetupConfigurationPanel::onConfigurationChanged);
+  connect(m_threadPitchSpin,
+          QOverload<double>::of(&QDoubleSpinBox::valueChanged), this,
+          &SetupConfigurationPanel::onConfigurationChanged);
+  connect(m_chamferSizeSpin,
+          QOverload<double>::of(&QDoubleSpinBox::valueChanged), this,
+          &SetupConfigurationPanel::onConfigurationChanged);
+
+  connect(m_surfaceFinishCombo,
+          QOverload<int>::of(&QComboBox::currentIndexChanged), this,
+          &SetupConfigurationPanel::onConfigurationChanged);
+  connect(m_toleranceSpin, QOverload<double>::of(&QDoubleSpinBox::valueChanged),
+          this, &SetupConfigurationPanel::onConfigurationChanged);
+
+  // Operation controls - only connect if widgets exist
+  if (m_contouringEnabledCheck) {
+    connect(m_contouringEnabledCheck, &QCheckBox::toggled, this,
+            &SetupConfigurationPanel::onOperationToggled);
+  }
+  if (m_threadingEnabledCheck) {
+    connect(m_threadingEnabledCheck, &QCheckBox::toggled, this,
+            &SetupConfigurationPanel::onOperationToggled);
+  }
+  if (m_chamferingEnabledCheck) {
+    connect(m_chamferingEnabledCheck, &QCheckBox::toggled, this,
+            &SetupConfigurationPanel::onOperationToggled);
+  }
+  if (m_partingEnabledCheck) {
+    connect(m_partingEnabledCheck, &QCheckBox::toggled, this,
+            &SetupConfigurationPanel::onOperationToggled);
+  }
 }
 
-void SetupConfigurationPanel::applyTabStyling()
-{
-    // Apply modern styling to tab widget
-    m_operationsTabWidget->setStyleSheet(R"(
+void SetupConfigurationPanel::applyTabStyling() {
+  // Apply modern styling to tab widget
+  m_operationsTabWidget->setStyleSheet(R"(
         QTabWidget::pane {
             border: 1px solid #c0c0c0;
             background-color: #f0f0f0;
@@ -614,8 +714,8 @@ void SetupConfigurationPanel::applyTabStyling()
         }
     )");
 
-    // Style the group boxes with modern colors
-    QString groupBoxStyle = R"(
+  // Style the group boxes with modern colors
+  QString groupBoxStyle = R"(
         QGroupBox {
             font-weight: bold;
             border: 2px solid %1;
@@ -634,462 +734,517 @@ void SetupConfigurationPanel::applyTabStyling()
         }
     )";
 
-    m_partSetupGroup->setStyleSheet(groupBoxStyle.arg("#2196F3", "33, 150, 243"));
-    m_materialGroup->setStyleSheet(groupBoxStyle.arg("#4CAF50", "76, 175, 80"));
-    m_machiningParamsGroup->setStyleSheet(groupBoxStyle.arg("#f44336", "244, 67, 54"));
-    m_qualityGroup->setStyleSheet(groupBoxStyle.arg("#607D8B", "96, 125, 139"));
+  m_partSetupGroup->setStyleSheet(groupBoxStyle.arg("#2196F3", "33, 150, 243"));
+  m_materialGroup->setStyleSheet(groupBoxStyle.arg("#4CAF50", "76, 175, 80"));
+  m_machiningParamsGroup->setStyleSheet(
+      groupBoxStyle.arg("#f44336", "244, 67, 54"));
+  m_qualityGroup->setStyleSheet(groupBoxStyle.arg("#607D8B", "96, 125, 139"));
 }
 
 // Getter implementations
-QString SetupConfigurationPanel::getStepFilePath() const
-{
-    return m_stepFileEdit->text();
+QString SetupConfigurationPanel::getStepFilePath() const {
+  return m_stepFileEdit->text();
 }
 
-MaterialType SetupConfigurationPanel::getMaterialType() const
-{
-    return static_cast<MaterialType>(m_materialTypeCombo->currentIndex());
+MaterialType SetupConfigurationPanel::getMaterialType() const {
+  return static_cast<MaterialType>(m_materialTypeCombo->currentIndex());
 }
 
-double SetupConfigurationPanel::getRawDiameter() const
-{
-    return m_rawDiameterSpin->value();
+double SetupConfigurationPanel::getRawDiameter() const {
+  return m_rawDiameterSpin->value();
 }
 
-double SetupConfigurationPanel::getDistanceToChuck() const
-{
-    return m_distanceSpinBox->value();
+double SetupConfigurationPanel::getDistanceToChuck() const {
+  return m_distanceSpinBox->value();
 }
 
-bool SetupConfigurationPanel::isOrientationFlipped() const
-{
-    return m_flipOrientationCheckBox->isChecked();
+bool SetupConfigurationPanel::isOrientationFlipped() const {
+  return m_flipOrientationCheckBox->isChecked();
 }
 
-double SetupConfigurationPanel::getFacingAllowance() const
-{
-    return m_facingAllowanceSpin->value();
+double SetupConfigurationPanel::getFacingAllowance() const {
+  return m_facingAllowanceSpin->value();
 }
 
-double SetupConfigurationPanel::getRoughingAllowance() const
-{
-    return m_roughingAllowanceSpin->value();
+double SetupConfigurationPanel::getRoughingAllowance() const {
+  return m_roughingAllowanceSpin->value();
 }
 
-double SetupConfigurationPanel::getFinishingAllowance() const
-{
-    return m_finishingAllowanceSpin->value();
+double SetupConfigurationPanel::getFinishingAllowance() const {
+  return m_finishingAllowanceSpin->value();
 }
 
-double SetupConfigurationPanel::getPartingWidth() const
-{
-    return m_partingWidthSpin->value();
+double SetupConfigurationPanel::getPartingWidth() const {
+  return m_partingWidthSpin->value();
 }
 
-SurfaceFinish SetupConfigurationPanel::getSurfaceFinish() const
-{
-    return static_cast<SurfaceFinish>(m_surfaceFinishCombo->currentIndex());
+SurfaceFinish SetupConfigurationPanel::getSurfaceFinish() const {
+  return static_cast<SurfaceFinish>(m_surfaceFinishCombo->currentIndex());
 }
 
-double SetupConfigurationPanel::getTolerance() const
-{
-    return m_toleranceSpin->value();
+double SetupConfigurationPanel::getTolerance() const {
+  return m_toleranceSpin->value();
 }
 
-bool SetupConfigurationPanel::isOperationEnabled(const QString& operationName) const
-{
-    if (operationName == "Contouring") return m_contouringEnabledCheck ? m_contouringEnabledCheck->isChecked() : false;
-    if (operationName == "Threading") return m_threadingEnabledCheck ? m_threadingEnabledCheck->isChecked() : false;
-    if (operationName == "Chamfering") return m_chamferingEnabledCheck ? m_chamferingEnabledCheck->isChecked() : false;
-    if (operationName == "Parting") return m_partingEnabledCheck ? m_partingEnabledCheck->isChecked() : false;
-    return false;
+bool SetupConfigurationPanel::isOperationEnabled(
+    const QString &operationName) const {
+  if (operationName == "Contouring")
+    return m_contouringEnabledCheck ? m_contouringEnabledCheck->isChecked()
+                                    : false;
+  if (operationName == "Threading")
+    return m_threadingEnabledCheck ? m_threadingEnabledCheck->isChecked()
+                                   : false;
+  if (operationName == "Chamfering")
+    return m_chamferingEnabledCheck ? m_chamferingEnabledCheck->isChecked()
+                                    : false;
+  if (operationName == "Parting")
+    return m_partingEnabledCheck ? m_partingEnabledCheck->isChecked() : false;
+  return false;
 }
 
-OperationConfig SetupConfigurationPanel::getOperationConfig(const QString& operationName) const
-{
-    OperationConfig config;
-    config.enabled = isOperationEnabled(operationName);
-    config.name = operationName;
-    config.description = QString("%1 operation").arg(operationName);
-    return config;
+OperationConfig SetupConfigurationPanel::getOperationConfig(
+    const QString &operationName) const {
+  OperationConfig config;
+  config.enabled = isOperationEnabled(operationName);
+  config.name = operationName;
+  config.description = QString("%1 operation").arg(operationName);
+  return config;
 }
 
 // Setter implementations
-void SetupConfigurationPanel::setStepFilePath(const QString& path)
-{
-    m_stepFileEdit->setText(path);
+void SetupConfigurationPanel::setStepFilePath(const QString &path) {
+  m_stepFileEdit->setText(path);
 }
 
-void SetupConfigurationPanel::setMaterialType(MaterialType type)
-{
-    m_materialTypeCombo->setCurrentIndex(static_cast<int>(type));
+void SetupConfigurationPanel::setMaterialType(MaterialType type) {
+  m_materialTypeCombo->setCurrentIndex(static_cast<int>(type));
 }
 
-void SetupConfigurationPanel::setRawDiameter(double diameter)
-{
-    m_rawDiameterSpin->setValue(diameter);
+void SetupConfigurationPanel::setRawDiameter(double diameter) {
+  m_rawDiameterSpin->setValue(diameter);
 }
 
-void SetupConfigurationPanel::setDistanceToChuck(double distance)
-{
-    m_distanceSlider->setValue(static_cast<int>(distance));
-    m_distanceSpinBox->setValue(distance);
+void SetupConfigurationPanel::setDistanceToChuck(double distance) {
+  m_distanceSlider->setValue(static_cast<int>(distance));
+  m_distanceSpinBox->setValue(distance);
 }
 
-void SetupConfigurationPanel::setOrientationFlipped(bool flipped)
-{
-    m_flipOrientationCheckBox->setChecked(flipped);
+void SetupConfigurationPanel::setOrientationFlipped(bool flipped) {
+  m_flipOrientationCheckBox->setChecked(flipped);
 }
 
-void SetupConfigurationPanel::updateRawMaterialLength(double length)
-{
-    m_rawLengthLabel->setText(QString("Raw Length: %1 mm (auto-calculated)").arg(length, 0, 'f', 1));
+void SetupConfigurationPanel::updateRawMaterialLength(double length) {
+  m_rawLengthLabel->setText(
+      QString("Raw Length: %1 mm (auto-calculated)").arg(length, 0, 'f', 1));
 }
 
-void SetupConfigurationPanel::setFacingAllowance(double allowance)
-{
-    m_facingAllowanceSpin->setValue(allowance);
+void SetupConfigurationPanel::setFacingAllowance(double allowance) {
+  m_facingAllowanceSpin->setValue(allowance);
 }
 
-void SetupConfigurationPanel::setRoughingAllowance(double allowance)
-{
-    m_roughingAllowanceSpin->setValue(allowance);
+void SetupConfigurationPanel::setRoughingAllowance(double allowance) {
+  m_roughingAllowanceSpin->setValue(allowance);
 }
 
-void SetupConfigurationPanel::setFinishingAllowance(double allowance)
-{
-    m_finishingAllowanceSpin->setValue(allowance);
+void SetupConfigurationPanel::setFinishingAllowance(double allowance) {
+  m_finishingAllowanceSpin->setValue(allowance);
 }
 
-void SetupConfigurationPanel::setPartingWidth(double width)
-{
-    m_partingWidthSpin->setValue(width);
+void SetupConfigurationPanel::setPartingWidth(double width) {
+  m_partingWidthSpin->setValue(width);
 }
 
-void SetupConfigurationPanel::setSurfaceFinish(SurfaceFinish finish)
-{
-    m_surfaceFinishCombo->setCurrentIndex(static_cast<int>(finish));
+void SetupConfigurationPanel::setSurfaceFinish(SurfaceFinish finish) {
+  m_surfaceFinishCombo->setCurrentIndex(static_cast<int>(finish));
 }
 
-void SetupConfigurationPanel::setTolerance(double tolerance)
-{
-    m_toleranceSpin->setValue(tolerance);
+void SetupConfigurationPanel::setTolerance(double tolerance) {
+  m_toleranceSpin->setValue(tolerance);
 }
 
-void SetupConfigurationPanel::setOperationEnabled(const QString& operationName, bool enabled)
-{
-    if (operationName == "Contouring" && m_contouringEnabledCheck) {
-        QSignalBlocker blocker(m_contouringEnabledCheck);
-        m_contouringEnabledCheck->setChecked(enabled);
-    } else if (operationName == "Threading" && m_threadingEnabledCheck) {
-        QSignalBlocker blocker(m_threadingEnabledCheck);
-        m_threadingEnabledCheck->setChecked(enabled);
-    } else if (operationName == "Chamfering" && m_chamferingEnabledCheck) {
-        QSignalBlocker blocker(m_chamferingEnabledCheck);
-        m_chamferingEnabledCheck->setChecked(enabled);
-    } else if (operationName == "Parting" && m_partingEnabledCheck) {
-        QSignalBlocker blocker(m_partingEnabledCheck);
-        m_partingEnabledCheck->setChecked(enabled);
-    }
+void SetupConfigurationPanel::setOperationEnabled(const QString &operationName,
+                                                  bool enabled) {
+  if (operationName == "Contouring" && m_contouringEnabledCheck) {
+    QSignalBlocker blocker(m_contouringEnabledCheck);
+    m_contouringEnabledCheck->setChecked(enabled);
+  } else if (operationName == "Threading" && m_threadingEnabledCheck) {
+    QSignalBlocker blocker(m_threadingEnabledCheck);
+    m_threadingEnabledCheck->setChecked(enabled);
+  } else if (operationName == "Chamfering" && m_chamferingEnabledCheck) {
+    QSignalBlocker blocker(m_chamferingEnabledCheck);
+    m_chamferingEnabledCheck->setChecked(enabled);
+  } else if (operationName == "Parting" && m_partingEnabledCheck) {
+    QSignalBlocker blocker(m_partingEnabledCheck);
+    m_partingEnabledCheck->setChecked(enabled);
+  }
 
-    updateOperationControls();
+  updateOperationControls();
 }
 
-void SetupConfigurationPanel::updateAxisInfo(const QString& info)
-{
-    m_axisInfoLabel->setText(info);
+void SetupConfigurationPanel::updateAxisInfo(const QString &info) {
+  m_axisInfoLabel->setText(info);
 }
 
 // Slot implementations
-void SetupConfigurationPanel::onBrowseStepFile()
-{
-    QString fileName = QFileDialog::getOpenFileName(this,
-        tr("Select STEP File"), QString(),
-        tr("STEP Files (*.step *.stp);;All Files (*)"));
-    
-    if (!fileName.isEmpty()) {
-        m_stepFileEdit->setText(fileName);
-        emit stepFileSelected(fileName);
-        emit configurationChanged();
-    }
-}
+void SetupConfigurationPanel::onBrowseStepFile() {
+  QString fileName = QFileDialog::getOpenFileName(
+      this, tr("Select STEP File"), QString(),
+      tr("STEP Files (*.step *.stp);;All Files (*)"));
 
-void SetupConfigurationPanel::onManualAxisSelectionClicked()
-{
-    emit manualAxisSelectionRequested();
-    m_axisInfoLabel->setText("Selection mode enabled - click on a cylindrical surface or circular edge in the 3D view");
-}
-
-void SetupConfigurationPanel::onConfigurationChanged()
-{
+  if (!fileName.isEmpty()) {
+    m_stepFileEdit->setText(fileName);
+    emit stepFileSelected(fileName);
     emit configurationChanged();
-    
-    // Emit specific signals for certain changes
-    QObject* sender = this->sender();
-    if (sender == m_materialTypeCombo) {
-        emit materialTypeChanged(getMaterialType());
-    }
-    if (sender == m_rawDiameterSpin) {
-        emit rawMaterialDiameterChanged(getRawDiameter());
-    }
+  }
 }
 
-void SetupConfigurationPanel::onOperationToggled()
-{
-    QCheckBox* checkBox = qobject_cast<QCheckBox*>(sender());
-    if (checkBox) {
-        QString operationName;
-        if (checkBox == m_contouringEnabledCheck) operationName = "Contouring";
-        else if (checkBox == m_threadingEnabledCheck) operationName = "Threading";
-        else if (checkBox == m_chamferingEnabledCheck) operationName = "Chamfering";
-        else if (checkBox == m_partingEnabledCheck) operationName = "Parting";
-
-        bool enabled = checkBox->isChecked();
-        emit operationToggled(operationName, enabled);
-        emit configurationChanged();
-        updateOperationControls();
-        // Triggering automatic generation here caused crashes when the
-        // ToolpathGenerationController was not fully initialized.  Until the
-        // generation pipeline is more robust we simply avoid starting it
-        // automatically when toggling an operation from the setup tab.
-        // if (enabled) {
-        //     emit automaticToolpathGenerationRequested();
-        // }
-    }
+void SetupConfigurationPanel::onManualAxisSelectionClicked() {
+  emit manualAxisSelectionRequested();
+  m_axisInfoLabel->setText("Selection mode enabled - click on a cylindrical "
+                           "surface or circular edge in the 3D view");
 }
 
+void SetupConfigurationPanel::onConfigurationChanged() {
+  emit configurationChanged();
 
-
-void SetupConfigurationPanel::setMaterialManager(MaterialManager* materialManager)
-{
-    m_materialManager = materialManager;
-    if (m_materialManager) {
-        // Update material combo box with materials from database
-        m_materialTypeCombo->clear();
-        QStringList materialNames = m_materialManager->getAllMaterialNames();
-        for (const QString& name : materialNames) {
-            MaterialProperties props = m_materialManager->getMaterialProperties(name);
-            m_materialTypeCombo->addItem(props.displayName, name);
-        }
-        
-        // Connect to material database changes
-        connect(m_materialManager, &MaterialManager::materialAdded,
-                this, &SetupConfigurationPanel::updateMaterialProperties);
-        connect(m_materialManager, &MaterialManager::materialUpdated,
-                this, &SetupConfigurationPanel::updateMaterialProperties);
-        
-        updateMaterialProperties();
-    }
+  // Emit specific signals for certain changes
+  QObject *sender = this->sender();
+  if (sender == m_materialTypeCombo) {
+    emit materialTypeChanged(getMaterialType());
+  }
+  if (sender == m_rawDiameterSpin) {
+    emit rawMaterialDiameterChanged(getRawDiameter());
+  }
 }
 
-void SetupConfigurationPanel::setToolManager(ToolManager* toolManager)
-{
-    m_toolManager = toolManager;
-    if (m_toolManager) {
-        // Connect to tool database changes
-        connect(m_toolManager, &ToolManager::toolAdded,
-                this, &SetupConfigurationPanel::updateToolRecommendations);
-        connect(m_toolManager, &ToolManager::toolUpdated,
-                this, &SetupConfigurationPanel::updateToolRecommendations);
-        
-        updateToolRecommendations();
-    }
+void SetupConfigurationPanel::onOperationToggled() {
+  QCheckBox *checkBox = qobject_cast<QCheckBox *>(sender());
+  if (checkBox) {
+    QString operationName;
+    if (checkBox == m_contouringEnabledCheck)
+      operationName = "Contouring";
+    else if (checkBox == m_threadingEnabledCheck)
+      operationName = "Threading";
+    else if (checkBox == m_chamferingEnabledCheck)
+      operationName = "Chamfering";
+    else if (checkBox == m_partingEnabledCheck)
+      operationName = "Parting";
+
+    bool enabled = checkBox->isChecked();
+    emit operationToggled(operationName, enabled);
+    emit configurationChanged();
+    updateOperationControls();
+    // Triggering automatic generation here caused crashes when the
+    // ToolpathGenerationController was not fully initialized.  Until the
+    // generation pipeline is more robust we simply avoid starting it
+    // automatically when toggling an operation from the setup tab.
+    // if (enabled) {
+    //     emit automaticToolpathGenerationRequested();
+    // }
+  }
 }
 
-QString SetupConfigurationPanel::getSelectedMaterialName() const
-{
-    if (m_materialTypeCombo->currentIndex() >= 0) {
-        return m_materialTypeCombo->currentData().toString();
-    }
-    return QString();
-}
-
-QStringList SetupConfigurationPanel::getRecommendedTools() const
-{
-    QStringList toolIds;
-    for (auto list : m_operationToolLists) {
-        if (!list) continue;
-        for (int i = 0; i < list->count(); ++i) {
-            QListWidgetItem* item = list->item(i);
-            if (item && item->data(Qt::UserRole).isValid()) {
-                toolIds.append(item->data(Qt::UserRole).toString());
-            }
-        }
-    }
-    return toolIds;
-}
-
-void SetupConfigurationPanel::updateMaterialProperties()
-{
-    if (!m_materialManager || !m_materialPropertiesLabel) {
-        return;
-    }
-    
-    QString materialName = getSelectedMaterialName();
-    if (materialName.isEmpty()) {
-        m_materialPropertiesLabel->setText("No material selected");
-        return;
-    }
-    
-    MaterialProperties props = m_materialManager->getMaterialProperties(materialName);
-    if (props.name.isEmpty()) {
-        m_materialPropertiesLabel->setText("Material properties not available");
-        return;
-    }
-    
-    QString propertiesText = QString(
-        "Density: %1 kg/m³\n"
-        "Machinability: %2/10\n"
-        "Recommended Speed: %3 m/min\n"
-        "Recommended Feed: %4 mm/rev"
-    ).arg(props.density, 0, 'f', 0)
-     .arg(props.machinabilityRating * 10, 0, 'f', 1)
-     .arg(props.recommendedSurfaceSpeed, 0, 'f', 0)
-     .arg(props.recommendedFeedRate, 0, 'f', 2);
-    
-    m_materialPropertiesLabel->setText(propertiesText);
-    
-    // Update tool recommendations when material changes
-    updateToolRecommendations();
-    
-    emit materialSelectionChanged(materialName);
-}
-
-void SetupConfigurationPanel::updateToolRecommendations()
-{
-    if (!m_toolManager) {
-        return;
+void SetupConfigurationPanel::setMaterialManager(
+    MaterialManager *materialManager) {
+  m_materialManager = materialManager;
+  if (m_materialManager) {
+    // Update material combo box with materials from database
+    m_materialTypeCombo->clear();
+    QStringList materialNames = m_materialManager->getAllMaterialNames();
+    for (const QString &name : materialNames) {
+      MaterialProperties props = m_materialManager->getMaterialProperties(name);
+      m_materialTypeCombo->addItem(props.displayName, name);
     }
 
-    for (auto list : m_operationToolLists) {
-        if (list) list->clear();
-    }
-    
-    QString materialName = getSelectedMaterialName();
-    if (materialName.isEmpty()) {
-        return;
-    }
-    
-    double workpieceDiameter = getRawDiameter();
-    double surfaceFinish = 16.0; // Default medium finish
-    
-    // Get surface finish target from UI
-    SurfaceFinish finish = getSurfaceFinish();
-    switch (finish) {
-        case SurfaceFinish::Mirror_1Ra: surfaceFinish = 1.0; break;
-        case SurfaceFinish::Polish_2Ra: surfaceFinish = 2.0; break;
-        case SurfaceFinish::Smooth_4Ra: surfaceFinish = 4.0; break;
-        case SurfaceFinish::Fine_8Ra: surfaceFinish = 8.0; break;
-        case SurfaceFinish::Medium_16Ra: surfaceFinish = 16.0; break;
-        case SurfaceFinish::Rough_32Ra: surfaceFinish = 32.0; break;
-    }
-    
-    // Get tool recommendations for each enabled operation
-    QStringList operations;
-    if (isOperationEnabled("Contouring")) operations.append("contouring");
-    if (isOperationEnabled("Threading")) operations.append("threading");
-    if (isOperationEnabled("Chamfering")) operations.append("chamfering");
-    if (isOperationEnabled("Parting")) operations.append("parting");
-    
-    QSet<QString> recommendedToolIds;
-    
-    for (const QString& operation : operations) {
-        auto recommendations = m_toolManager->recommendTools(
-            operation, materialName, workpieceDiameter, surfaceFinish);
-        
-        // Add top 2 recommendations for each operation
-        int count = 0;
-        for (const auto& rec : recommendations) {
-            if (count >= 2) break;
-            if (!recommendedToolIds.contains(rec.toolId)) {
-                recommendedToolIds.insert(rec.toolId);
-                
-                CuttingTool tool = m_toolManager->getTool(rec.toolId);
-                QString itemText = QString("%1 - %2 (%3)")
-                    .arg(tool.name)
-                    .arg(operation)
-                    .arg(rec.suitabilityScore, 0, 'f', 2);
-                
-                QListWidgetItem* item = new QListWidgetItem(itemText);
-                item->setData(Qt::UserRole, QVariant(rec.toolId));
-                item->setToolTip(QString("Tool: %1\nOperation: %2\nSuitability: %3\nReason: %4")
-                    .arg(tool.name).arg(operation).arg(rec.suitabilityScore, 0, 'f', 2).arg(rec.reason));
+    // Connect to material database changes
+    connect(m_materialManager, &MaterialManager::materialAdded, this,
+            &SetupConfigurationPanel::updateMaterialProperties);
+    connect(m_materialManager, &MaterialManager::materialUpdated, this,
+            &SetupConfigurationPanel::updateMaterialProperties);
 
-                QListWidget* targetList = m_operationToolLists.value(operation);
-                if (targetList) {
-                    targetList->addItem(item);
-                }
-                count++;
-            }
-        }
-    }
-    
-    emit toolRecommendationsUpdated(QStringList(recommendedToolIds.begin(), recommendedToolIds.end()));
-}
-
-void SetupConfigurationPanel::onMaterialChanged()
-{
     updateMaterialProperties();
-    emit configurationChanged();
+  }
 }
 
-void SetupConfigurationPanel::onToolSelectionRequested()
-{
-    // This could open a tool selection dialog or provide more detailed tool information
-    QStringList selectedTools = getRecommendedTools();
-    if (!selectedTools.isEmpty()) {
-        qDebug() << "Selected tools:" << selectedTools;
-        // Here we could emit a signal to show detailed tool information
+void SetupConfigurationPanel::setToolManager(ToolManager *toolManager) {
+  m_toolManager = toolManager;
+  if (m_toolManager) {
+    // Connect to tool database changes
+    connect(m_toolManager, &ToolManager::toolAdded, this,
+            &SetupConfigurationPanel::updateToolRecommendations);
+    connect(m_toolManager, &ToolManager::toolUpdated, this,
+            &SetupConfigurationPanel::updateToolRecommendations);
+
+    updateToolRecommendations();
+  }
+}
+
+QString SetupConfigurationPanel::getSelectedMaterialName() const {
+  if (m_materialTypeCombo->currentIndex() >= 0) {
+    return m_materialTypeCombo->currentData().toString();
+  }
+  return QString();
+}
+
+QStringList SetupConfigurationPanel::getRecommendedTools() const {
+  QStringList toolIds;
+  for (auto list : m_operationToolLists) {
+    if (!list)
+      continue;
+    for (int i = 0; i < list->count(); ++i) {
+      QListWidgetItem *item = list->item(i);
+      if (item && item->data(Qt::UserRole).isValid()) {
+        toolIds.append(item->data(Qt::UserRole).toString());
+      }
     }
+  }
+  return toolIds;
 }
 
-void SetupConfigurationPanel::updateOperationControls()
-{
-    // Placeholder for any additional per-operation controls
+void SetupConfigurationPanel::updateMaterialProperties() {
+  if (!m_materialManager || !m_materialPropertiesLabel) {
+    return;
+  }
+
+  QString materialName = getSelectedMaterialName();
+  if (materialName.isEmpty()) {
+    m_materialPropertiesLabel->setText("No material selected");
+    return;
+  }
+
+  MaterialProperties props =
+      m_materialManager->getMaterialProperties(materialName);
+  if (props.name.isEmpty()) {
+    m_materialPropertiesLabel->setText("Material properties not available");
+    return;
+  }
+
+  QString propertiesText = QString("Density: %1 kg/m³\n"
+                                   "Machinability: %2/10\n"
+                                   "Recommended Speed: %3 m/min\n"
+                                   "Recommended Feed: %4 mm/rev")
+                               .arg(props.density, 0, 'f', 0)
+                               .arg(props.machinabilityRating * 10, 0, 'f', 1)
+                               .arg(props.recommendedSurfaceSpeed, 0, 'f', 0)
+                               .arg(props.recommendedFeedRate, 0, 'f', 2);
+
+  m_materialPropertiesLabel->setText(propertiesText);
+
+  // Update tool recommendations when material changes
+  updateToolRecommendations();
+
+  emit materialSelectionChanged(materialName);
 }
 
-void SetupConfigurationPanel::focusOperationTab(const QString& operationName)
-{
-    int index = 0;
-    if (operationName.compare("Contouring", Qt::CaseInsensitive) == 0)
-        index = 0;
-    else if (operationName.compare("Threading", Qt::CaseInsensitive) == 0)
-        index = 1;
-    else if (operationName.compare("Chamfering", Qt::CaseInsensitive) == 0)
-        index = 2;
-    else if (operationName.compare("Parting", Qt::CaseInsensitive) == 0)
-        index = 3;
-    if (m_operationsTabWidget)
-        m_operationsTabWidget->setCurrentIndex(index);
+void SetupConfigurationPanel::updateToolRecommendations() {
+  if (!m_toolManager) {
+    return;
+  }
+
+  for (auto list : m_operationToolLists) {
+    if (list)
+      list->clear();
+  }
+
+  QString materialName = getSelectedMaterialName();
+  if (materialName.isEmpty()) {
+    return;
+  }
+
+  double workpieceDiameter = getRawDiameter();
+  double surfaceFinish = 16.0; // Default medium finish
+
+  // Get surface finish target from UI
+  SurfaceFinish finish = getSurfaceFinish();
+  switch (finish) {
+  case SurfaceFinish::Mirror_1Ra:
+    surfaceFinish = 1.0;
+    break;
+  case SurfaceFinish::Polish_2Ra:
+    surfaceFinish = 2.0;
+    break;
+  case SurfaceFinish::Smooth_4Ra:
+    surfaceFinish = 4.0;
+    break;
+  case SurfaceFinish::Fine_8Ra:
+    surfaceFinish = 8.0;
+    break;
+  case SurfaceFinish::Medium_16Ra:
+    surfaceFinish = 16.0;
+    break;
+  case SurfaceFinish::Rough_32Ra:
+    surfaceFinish = 32.0;
+    break;
+  }
+
+  // Get tool recommendations for each enabled operation
+  QStringList operations;
+  if (isOperationEnabled("Contouring"))
+    operations.append("contouring");
+  if (isOperationEnabled("Threading"))
+    operations.append("threading");
+  if (isOperationEnabled("Chamfering"))
+    operations.append("chamfering");
+  if (isOperationEnabled("Parting"))
+    operations.append("parting");
+
+  QSet<QString> recommendedToolIds;
+
+  for (const QString &operation : operations) {
+    auto recommendations = m_toolManager->recommendTools(
+        operation, materialName, workpieceDiameter, surfaceFinish);
+
+    // Add top 2 recommendations for each operation
+    int count = 0;
+    for (const auto &rec : recommendations) {
+      if (count >= 2)
+        break;
+      if (!recommendedToolIds.contains(rec.toolId)) {
+        recommendedToolIds.insert(rec.toolId);
+
+        CuttingTool tool = m_toolManager->getTool(rec.toolId);
+        QString itemText = QString("%1 - %2 (%3)")
+                               .arg(tool.name)
+                               .arg(operation)
+                               .arg(rec.suitabilityScore, 0, 'f', 2);
+
+        QListWidgetItem *item = new QListWidgetItem(itemText);
+        item->setData(Qt::UserRole, QVariant(rec.toolId));
+        item->setToolTip(
+            QString("Tool: %1\nOperation: %2\nSuitability: %3\nReason: %4")
+                .arg(tool.name)
+                .arg(operation)
+                .arg(rec.suitabilityScore, 0, 'f', 2)
+                .arg(rec.reason));
+
+        QListWidget *targetList = m_operationToolLists.value(operation);
+        if (targetList) {
+          targetList->addItem(item);
+        }
+        count++;
+      }
+    }
+  }
+
+  emit toolRecommendationsUpdated(
+      QStringList(recommendedToolIds.begin(), recommendedToolIds.end()));
+}
+
+void SetupConfigurationPanel::onMaterialChanged() {
+  updateMaterialProperties();
+  emit configurationChanged();
+}
+
+void SetupConfigurationPanel::onToolSelectionRequested() {
+  // This could open a tool selection dialog or provide more detailed tool
+  // information
+  QStringList selectedTools = getRecommendedTools();
+  if (!selectedTools.isEmpty()) {
+    qDebug() << "Selected tools:" << selectedTools;
+    // Here we could emit a signal to show detailed tool information
+  }
+}
+
+void SetupConfigurationPanel::updateOperationControls() {
+  // Placeholder for any additional per-operation controls
+}
+
+void SetupConfigurationPanel::updateAdvancedMode() {
+  bool adv = m_advancedModeCheck && m_advancedModeCheck->isChecked();
+
+  if (m_roughingAllowanceLabel)
+    m_roughingAllowanceLabel->setVisible(adv);
+  if (m_roughingAllowanceSpin)
+    m_roughingAllowanceSpin->setVisible(adv);
+  if (m_finishingAllowanceLabel)
+    m_finishingAllowanceLabel->setVisible(adv);
+  if (m_finishingAllowanceSpin)
+    m_finishingAllowanceSpin->setVisible(adv);
+  if (m_partingWidthLabel)
+    m_partingWidthLabel->setVisible(adv);
+  if (m_partingWidthSpin)
+    m_partingWidthSpin->setVisible(adv);
+  if (m_toleranceLabel)
+    m_toleranceLabel->setVisible(adv);
+  if (m_toleranceSpin)
+    m_toleranceSpin->setVisible(adv);
+  if (m_contourAdvancedGroup)
+    m_contourAdvancedGroup->setVisible(adv);
+
+  if (adv && m_materialManager) {
+    QString materialName = getSelectedMaterialName();
+    double finishVal = 16.0;
+    switch (getSurfaceFinish()) {
+    case SurfaceFinish::Mirror_1Ra:
+      finishVal = 1.0;
+      break;
+    case SurfaceFinish::Polish_2Ra:
+      finishVal = 2.0;
+      break;
+    case SurfaceFinish::Smooth_4Ra:
+      finishVal = 4.0;
+      break;
+    case SurfaceFinish::Fine_8Ra:
+      finishVal = 8.0;
+      break;
+    case SurfaceFinish::Medium_16Ra:
+      finishVal = 16.0;
+      break;
+    case SurfaceFinish::Rough_32Ra:
+      finishVal = 32.0;
+      break;
+    }
+    CuttingParameters cp = m_materialManager->calculateCuttingParameters(
+        materialName, 10.0, "facing", finishVal);
+    if (m_contourDepthSpin)
+      m_contourDepthSpin->setValue(cp.depthOfCut);
+    if (m_contourFeedSpin)
+      m_contourFeedSpin->setValue(cp.feedRate);
+    if (m_contourSpeedSpin)
+      m_contourSpeedSpin->setValue(cp.spindleSpeed);
+  }
+}
+
+void SetupConfigurationPanel::focusOperationTab(const QString &operationName) {
+  int index = 0;
+  if (operationName.compare("Contouring", Qt::CaseInsensitive) == 0)
+    index = 0;
+  else if (operationName.compare("Threading", Qt::CaseInsensitive) == 0)
+    index = 1;
+  else if (operationName.compare("Chamfering", Qt::CaseInsensitive) == 0)
+    index = 2;
+  else if (operationName.compare("Parting", Qt::CaseInsensitive) == 0)
+    index = 3;
+  if (m_operationsTabWidget)
+    m_operationsTabWidget->setCurrentIndex(index);
 }
 
 // Utility method implementations
-QString SetupConfigurationPanel::materialTypeToString(MaterialType type)
-{
-    if (static_cast<int>(type) < MATERIAL_NAMES.size()) {
-        return MATERIAL_NAMES[static_cast<int>(type)];
-    }
-    return "Unknown";
+QString SetupConfigurationPanel::materialTypeToString(MaterialType type) {
+  if (static_cast<int>(type) < MATERIAL_NAMES.size()) {
+    return MATERIAL_NAMES[static_cast<int>(type)];
+  }
+  return "Unknown";
 }
 
-MaterialType SetupConfigurationPanel::stringToMaterialType(const QString& typeStr)
-{
-    int index = MATERIAL_NAMES.indexOf(typeStr);
-    return (index >= 0) ? static_cast<MaterialType>(index) : MaterialType::Custom;
+MaterialType
+SetupConfigurationPanel::stringToMaterialType(const QString &typeStr) {
+  int index = MATERIAL_NAMES.indexOf(typeStr);
+  return (index >= 0) ? static_cast<MaterialType>(index) : MaterialType::Custom;
 }
 
-QString SetupConfigurationPanel::surfaceFinishToString(SurfaceFinish finish)
-{
-    if (static_cast<int>(finish) < SURFACE_FINISH_NAMES.size()) {
-        return SURFACE_FINISH_NAMES[static_cast<int>(finish)];
-    }
-    return "Unknown";
+QString SetupConfigurationPanel::surfaceFinishToString(SurfaceFinish finish) {
+  if (static_cast<int>(finish) < SURFACE_FINISH_NAMES.size()) {
+    return SURFACE_FINISH_NAMES[static_cast<int>(finish)];
+  }
+  return "Unknown";
 }
 
-SurfaceFinish SetupConfigurationPanel::stringToSurfaceFinish(const QString& finishStr)
-{
-    int index = SURFACE_FINISH_NAMES.indexOf(finishStr);
-    return (index >= 0) ? static_cast<SurfaceFinish>(index) : SurfaceFinish::Medium_16Ra;
+SurfaceFinish
+SetupConfigurationPanel::stringToSurfaceFinish(const QString &finishStr) {
+  int index = SURFACE_FINISH_NAMES.indexOf(finishStr);
+  return (index >= 0) ? static_cast<SurfaceFinish>(index)
+                      : SurfaceFinish::Medium_16Ra;
 }
 
 } // namespace GUI


### PR DESCRIPTION
## Summary
- introduce advanced mode toggle and additional cutting parameter controls
- add tables for per-face threading and chamfering
- allow adjusting finishing pass count and extra chamfer stock
- document advanced mode in the workflow guide

## Testing
- `clang-format -i gui/include/setupconfigurationpanel.h gui/src/setupconfigurationpanel.cpp`
- `clang-tidy gui/src/setupconfigurationpanel.cpp -- -I./gui/include` *(fails: 'QCheckBox' file not found)*
- `cmake ..` *(fails: Could not find package configuration file provided by "Qt6")*

------
https://chatgpt.com/codex/tasks/task_e_684f18a447f483328677c449c4911559