### PR TITLE
Fix viewer black flash on focus switches

### DIFF
--- a/gui/src/opengl3dwidget.cpp
+++ b/gui/src/opengl3dwidget.cpp
@@ -52,8 +52,12 @@ OpenGL3DWidget::OpenGL3DWidget(QWidget *parent)
     setMouseTracking(true);
     setFocusPolicy(Qt::StrongFocus);
     
-    // Set update behavior to reduce flickering - use partial updates for better performance
-    setUpdateBehavior(QOpenGLWidget::PartialUpdate);
+    // Use the default full update behavior. Partial updates caused brief
+    // black flashes when the widget regained focus or another widget was
+    // interacted with. Following working OCCT viewer examples like
+    // gkv311/occt-samples-qopenglwidget, we stick with NoPartialUpdate to
+    // ensure consistent rendering.
+    setUpdateBehavior(QOpenGLWidget::NoPartialUpdate);
     
     // Ensure the widget gets proper resize events
     setAttribute(Qt::WA_OpaquePaintEvent);


### PR DESCRIPTION
## Summary
- avoid PartialUpdate in OpenGL viewer to prevent black flashes when focus changes

## Testing
- `cmake --preset ninja-release` *(fails: Could not find toolchain file and Ninja)*
- `ctest --test-dir build_ninja` *(fails: No tests were found)*

------
https://chatgpt.com/codex/tasks/task_e_684f1a441a90833286ca737e948045e5