### PR TITLE
Fix manual axis selection and skip chuck for 3D picking

### DIFF
--- a/gui/include/chuckmanager.h
+++ b/gui/include/chuckmanager.h
@@ -101,6 +101,12 @@ public:
      */
     bool isChuckVisible() const;
 
+    /**
+     * @brief Get the current chuck AIS object
+     * @return Current chuck AIS object, or null if not loaded
+     */
+    Handle(AIS_Shape) getChuckAIS() const { return m_chuckAIS; }
+
 signals:
     /**
      * @brief Emitted when chuck is successfully loaded

--- a/gui/src/mainwindow.cpp
+++ b/gui/src/mainwindow.cpp
@@ -1604,7 +1604,21 @@ void MainWindow::handleCylinderAxisSelected(int index, const CylinderInfo& cylin
 
 void MainWindow::handleManualAxisSelected(double diameter, const gp_Ax1& axis)
 {
-    // Placeholder
+    if (!m_workspaceController || !m_setupConfigPanel) {
+        return;
+    }
+
+    // Reapply part setup parameters so that manual axis selection behaves the
+    // same as initial part loading
+    double dist = m_setupConfigPanel->getDistanceToChuck();
+    double rawDia = m_setupConfigPanel->getRawDiameter();
+    bool flip = m_setupConfigPanel->isOrientationFlipped();
+
+    m_workspaceController->applyPartLoadingSettings(dist, rawDia, flip);
+
+    if (m_outputWindow) {
+        m_outputWindow->append("Manual axis selected - reapplied part setup parameters");
+    }
 }
 
 void MainWindow::handleRawMaterialCreated(double diameter, double length)

--- a/gui/src/opengl3dwidget.cpp
+++ b/gui/src/opengl3dwidget.cpp
@@ -564,12 +564,17 @@ void OpenGL3DWidget::setSelectionMode(bool enabled)
             AIS_ListOfInteractive allObjects;
             m_context->DisplayedObjects(allObjects);
             
-            // Get raw material AIS object if workspace controller is available
+            // Get raw material and chuck AIS objects if workspace controller is available
             Handle(AIS_Shape) rawMaterialAIS;
+            Handle(AIS_Shape) chuckAIS;
             if (m_workspaceController) {
                 RawMaterialManager* rawMaterialManager = m_workspaceController->getRawMaterialManager();
                 if (rawMaterialManager) {
                     rawMaterialAIS = rawMaterialManager->getCurrentRawMaterialAIS();
+                }
+                ChuckManager* chuckManager = m_workspaceController->getChuckManager();
+                if (chuckManager) {
+                    chuckAIS = chuckManager->getChuckAIS();
                 }
             }
             
@@ -580,6 +585,12 @@ void OpenGL3DWidget::setSelectionMode(bool enabled)
                     // Skip raw material - it should remain non-selectable
                     if (!rawMaterialAIS.IsNull() && aShape == rawMaterialAIS) {
                         qDebug() << "Skipping selection activation for raw material";
+                        continue;
+                    }
+
+                    // Skip chuck - it should remain non-selectable
+                    if (!chuckAIS.IsNull() && aShape == chuckAIS) {
+                        qDebug() << "Skipping selection activation for chuck";
                         continue;
                     }
                     


### PR DESCRIPTION
## Summary
- expose chuck AIS object via `ChuckManager`
- prevent raw material and chuck from being selectable when axis selection is active
- reapply part setup parameters after selecting axis from 3D view

## Testing
- `cmake -S . -B build` *(fails: Could not find Qt6Config.cmake)*

------
https://chatgpt.com/codex/tasks/task_e_684f19bffad8833299bc4c855092f1b2