### PR TITLE
Hide advanced parameters on startup

### DIFF
--- a/gui/src/setupconfigurationpanel.cpp
+++ b/gui/src/setupconfigurationpanel.cpp
@@ -77,6 +77,9 @@ SetupConfigurationPanel::SetupConfigurationPanel(QWidget *parent)
     setupUI();
     setupConnections();
     applyTabStyling();
+
+    // Ensure widgets respect the initial Advanced Mode state
+    updateAdvancedMode();
 }
 
 SetupConfigurationPanel::~SetupConfigurationPanel() {


### PR DESCRIPTION
## Summary
- ensure `updateAdvancedMode()` runs in `SetupConfigurationPanel` ctor so advanced widgets start hidden

## Testing
- `cmake --preset ninja-release` *(fails: Could not find toolchain file)*
- `ctest --preset ninja-release` *(fails: No tests were found)*

------
https://chatgpt.com/codex/tasks/task_e_685052d5121083329c745e84cae4fbe4