### PR TITLE
Add advanced contouring and parting options

### DIFF
--- a/docs/toolpath_workflow.md
+++ b/docs/toolpath_workflow.md
@@ -32,3 +32,7 @@ These settings are dedicated to lathe turning and are independent for every step
 The setup panel now offers a checkbox labeled **Advanced Mode**. When disabled, only the most important parameters are shown for each operation. For example, Contouring displays just the facing allowance, number of finishing passes and the final surface finish. Threading and Chamfering list the selected faces in tables where you can add or remove entries and adjust individual parameters.
 
 Enabling **Advanced Mode** reveals additional controls such as calculated cutting depth, feed rate and spindle speed. These values are pre‑filled from the material database but can be fine‑tuned manually.
+
+In this mode, Contouring exposes separate **Facing**, **Roughing** and **Finishing** sections. Each section lets you specify spindle speed (RPM), feed rate, surface speed and cutting depth and includes a checkbox for constant surface speed.
+Parting offers the same parameters plus a drop-down to choose the retract mode. When Advanced Mode is disabled, you simply enable or disable flood coolant for each operation.
+For Chamfering, the edge table now contains a *Chamfer Type* column allowing `Equal Distance`, `Two Distance` or `Distance & Angle` values per edge.

--- a/gui/include/setupconfigurationpanel.h
+++ b/gui/include/setupconfigurationpanel.h
@@ -195,10 +195,34 @@ private:
   QDoubleSpinBox *m_partingWidthSpin;
 
   // Advanced cutting parameter widgets
+  // Contouring advanced groups
   QGroupBox *m_contourAdvancedGroup;
+  QGroupBox *m_contourFacingGroup;
+  QGroupBox *m_contourRoughGroup;
+  QGroupBox *m_contourFinishGroup;
+  QDoubleSpinBox *m_contourFacingDepthSpin;
+  QDoubleSpinBox *m_contourFacingFeedSpin;
+  QDoubleSpinBox *m_contourFacingSpeedSpin;
+  QCheckBox *m_contourFacingCssCheck;
+  QDoubleSpinBox *m_contourRoughDepthSpin;
+  QDoubleSpinBox *m_contourRoughFeedSpin;
+  QDoubleSpinBox *m_contourRoughSpeedSpin;
+  QCheckBox *m_contourRoughCssCheck;
+  QDoubleSpinBox *m_contourFinishDepthSpin;
+  QDoubleSpinBox *m_contourFinishFeedSpin;
+  QDoubleSpinBox *m_contourFinishSpeedSpin;
+  QCheckBox *m_contourFinishCssCheck;
+
+  // Legacy flat advanced members kept for compatibility
   QDoubleSpinBox *m_contourDepthSpin;
   QDoubleSpinBox *m_contourFeedSpin;
   QDoubleSpinBox *m_contourSpeedSpin;
+
+  // Flood coolant (simple mode)
+  QCheckBox *m_contourFloodCheck;
+  QCheckBox *m_chamferFloodCheck;
+  QCheckBox *m_partFloodCheck;
+  QCheckBox *m_threadFloodCheck;
 
   // Advanced mode toggle
   QCheckBox *m_advancedModeCheck;
@@ -217,6 +241,14 @@ private:
   QPushButton *m_removeChamferFaceButton;
   QDoubleSpinBox *m_extraChamferStockSpin;
   QDoubleSpinBox *m_chamferDiameterLeaveSpin;
+
+  // Parting advanced group
+  QGroupBox *m_partingAdvancedGroup;
+  QDoubleSpinBox *m_partingDepthSpin;
+  QDoubleSpinBox *m_partingFeedSpin;
+  QDoubleSpinBox *m_partingSpeedSpin;
+  QCheckBox *m_partingCssCheck;
+  QComboBox *m_partingRetractCombo;
 
   // Legacy placeholders to preserve binary compatibility
   QGroupBox *m_operationsGroup;

--- a/gui/src/setupconfigurationpanel.cpp
+++ b/gui/src/setupconfigurationpanel.cpp
@@ -351,6 +351,14 @@ void SetupConfigurationPanel::setupMachiningTab() {
   finishPassLayout->addStretch();
   m_machiningParamsLayout->addLayout(finishPassLayout);
 
+  // Flood coolant simple toggle
+  QHBoxLayout *coolLayout = new QHBoxLayout();
+  m_contourFloodCheck = new QCheckBox("Flood Coolant");
+  m_contourFloodCheck->setChecked(true);
+  coolLayout->addWidget(m_contourFloodCheck);
+  coolLayout->addStretch();
+  m_machiningParamsLayout->addLayout(coolLayout);
+
   // Parting width
   m_partingWidthLayout = new QHBoxLayout();
   m_partingWidthLabel = new QLabel("Parting Width:");
@@ -418,19 +426,44 @@ void SetupConfigurationPanel::setupMachiningTab() {
 
   // Advanced cutting parameters
   m_contourAdvancedGroup = new QGroupBox("Advanced Cutting");
-  QFormLayout *contourAdvLayout = new QFormLayout(m_contourAdvancedGroup);
-  m_contourDepthSpin = new QDoubleSpinBox();
-  m_contourDepthSpin->setRange(0.01, 10.0);
-  m_contourDepthSpin->setSuffix(" mm");
-  m_contourFeedSpin = new QDoubleSpinBox();
-  m_contourFeedSpin->setRange(0.1, 1000.0);
-  m_contourFeedSpin->setSuffix(" mm/rev");
-  m_contourSpeedSpin = new QDoubleSpinBox();
-  m_contourSpeedSpin->setRange(10.0, 10000.0);
-  m_contourSpeedSpin->setSuffix(" RPM");
-  contourAdvLayout->addRow("Depth of Cut:", m_contourDepthSpin);
-  contourAdvLayout->addRow("Feed Rate:", m_contourFeedSpin);
-  contourAdvLayout->addRow("Spindle Speed:", m_contourSpeedSpin);
+  QVBoxLayout *contourAdvLayout = new QVBoxLayout(m_contourAdvancedGroup);
+
+  auto createSection = [this](const QString &title, QGroupBox **group,
+                              QDoubleSpinBox **depth, QDoubleSpinBox **feed,
+                              QDoubleSpinBox **speed, QCheckBox **css) {
+    *group = new QGroupBox(title);
+    QFormLayout *form = new QFormLayout(*group);
+    *depth = new QDoubleSpinBox();
+    (*depth)->setRange(0.01, 10.0);
+    (*depth)->setSuffix(" mm");
+    *feed = new QDoubleSpinBox();
+    (*feed)->setRange(0.1, 1000.0);
+    (*feed)->setSuffix(" mm/rev");
+    *speed = new QDoubleSpinBox();
+    (*speed)->setRange(10.0, 10000.0);
+    (*speed)->setSuffix(" RPM");
+    *css = new QCheckBox("Constant Surface Speed");
+    (*css)->setChecked(true);
+    form->addRow("Cut Depth:", *depth);
+    form->addRow("Feed Rate:", *feed);
+    form->addRow("Spindle Speed:", *speed);
+    form->addRow(QString(), *css);
+    return form;
+  };
+
+  createSection("Facing", &m_contourFacingGroup, &m_contourFacingDepthSpin,
+                &m_contourFacingFeedSpin, &m_contourFacingSpeedSpin,
+                &m_contourFacingCssCheck);
+  createSection("Roughing", &m_contourRoughGroup, &m_contourRoughDepthSpin,
+                &m_contourRoughFeedSpin, &m_contourRoughSpeedSpin,
+                &m_contourRoughCssCheck);
+  createSection("Finishing", &m_contourFinishGroup, &m_contourFinishDepthSpin,
+                &m_contourFinishFeedSpin, &m_contourFinishSpeedSpin,
+                &m_contourFinishCssCheck);
+
+  contourAdvLayout->addWidget(m_contourFacingGroup);
+  contourAdvLayout->addWidget(m_contourRoughGroup);
+  contourAdvLayout->addWidget(m_contourFinishGroup);
   contourLayout->addWidget(m_contourAdvancedGroup);
 
   contourLayout->addStretch();
@@ -460,6 +493,13 @@ void SetupConfigurationPanel::setupMachiningTab() {
   pitchLayout->addWidget(m_threadPitchSpin);
   pitchLayout->addStretch();
   threadingLayout->addLayout(pitchLayout);
+
+  QHBoxLayout *threadCoolLayout = new QHBoxLayout();
+  m_threadFloodCheck = new QCheckBox("Flood Coolant");
+  m_threadFloodCheck->setChecked(true);
+  threadCoolLayout->addWidget(m_threadFloodCheck);
+  threadCoolLayout->addStretch();
+  threadingLayout->addLayout(threadCoolLayout);
 
   m_threadFacesTable = new QTableWidget(0, 3);
   QStringList threadHeaders{"Face", "Preset", "Pitch"};
@@ -510,8 +550,15 @@ void SetupConfigurationPanel::setupMachiningTab() {
   chamferSizeLayout->addStretch();
   chamferLayout->addLayout(chamferSizeLayout);
 
+  QHBoxLayout *chamferCoolLayout = new QHBoxLayout();
+  m_chamferFloodCheck = new QCheckBox("Flood Coolant");
+  m_chamferFloodCheck->setChecked(true);
+  chamferCoolLayout->addWidget(m_chamferFloodCheck);
+  chamferCoolLayout->addStretch();
+  chamferLayout->addLayout(chamferCoolLayout);
+
   m_chamferFacesTable = new QTableWidget(0, 4);
-  QStringList chamferHeaders{"Face", "Symmetric", "Value A", "Value B"};
+  QStringList chamferHeaders{"Face", "Chamfer Type", "Value A", "Value B/Angle"};
   m_chamferFacesTable->setHorizontalHeaderLabels(chamferHeaders);
   m_chamferFacesTable->horizontalHeader()->setStretchLastSection(true);
   chamferLayout->addWidget(m_chamferFacesTable);
@@ -579,12 +626,42 @@ void SetupConfigurationPanel::setupMachiningTab() {
   m_partingWidthLayout->addStretch();
   partLayout->addLayout(m_partingWidthLayout);
 
+  QHBoxLayout *partCoolLayout = new QHBoxLayout();
+  m_partFloodCheck = new QCheckBox("Flood Coolant");
+  m_partFloodCheck->setChecked(true);
+  partCoolLayout->addWidget(m_partFloodCheck);
+  partCoolLayout->addStretch();
+  partLayout->addLayout(partCoolLayout);
+
   QGroupBox *partingToolsGroup = new QGroupBox("Recommended Tools");
   QVBoxLayout *partingToolsLayout = new QVBoxLayout(partingToolsGroup);
   QListWidget *partingToolsList = new QListWidget();
   partingToolsLayout->addWidget(partingToolsList);
   partLayout->addWidget(partingToolsGroup);
   m_operationToolLists.insert("parting", partingToolsList);
+
+  // Parting advanced parameters
+  m_partingAdvancedGroup = new QGroupBox("Advanced Cutting");
+  QFormLayout *partAdvLayout = new QFormLayout(m_partingAdvancedGroup);
+  m_partingDepthSpin = new QDoubleSpinBox();
+  m_partingDepthSpin->setRange(0.01, 5.0);
+  m_partingDepthSpin->setSuffix(" mm");
+  m_partingFeedSpin = new QDoubleSpinBox();
+  m_partingFeedSpin->setRange(0.1, 500.0);
+  m_partingFeedSpin->setSuffix(" mm/rev");
+  m_partingSpeedSpin = new QDoubleSpinBox();
+  m_partingSpeedSpin->setRange(10.0, 10000.0);
+  m_partingSpeedSpin->setSuffix(" RPM");
+  m_partingCssCheck = new QCheckBox("Constant Surface Speed");
+  m_partingCssCheck->setChecked(true);
+  m_partingRetractCombo = new QComboBox();
+  m_partingRetractCombo->addItems({"Direct", "Diagonal", "Custom"});
+  partAdvLayout->addRow("Cut Depth:", m_partingDepthSpin);
+  partAdvLayout->addRow("Feed Rate:", m_partingFeedSpin);
+  partAdvLayout->addRow("Spindle Speed:", m_partingSpeedSpin);
+  partAdvLayout->addRow("Retract Mode:", m_partingRetractCombo);
+  partAdvLayout->addRow(QString(), m_partingCssCheck);
+  partLayout->addWidget(m_partingAdvancedGroup);
 
   partLayout->addStretch();
 }
@@ -1134,12 +1211,23 @@ void SetupConfigurationPanel::updateAdvancedMode() {
     m_partingWidthLabel->setVisible(adv);
   if (m_partingWidthSpin)
     m_partingWidthSpin->setVisible(adv);
+  if (m_partingAdvancedGroup)
+    m_partingAdvancedGroup->setVisible(adv);
   if (m_toleranceLabel)
     m_toleranceLabel->setVisible(adv);
   if (m_toleranceSpin)
     m_toleranceSpin->setVisible(adv);
   if (m_contourAdvancedGroup)
     m_contourAdvancedGroup->setVisible(adv);
+
+  if (m_contourFloodCheck)
+    m_contourFloodCheck->setVisible(!adv);
+  if (m_threadFloodCheck)
+    m_threadFloodCheck->setVisible(!adv);
+  if (m_chamferFloodCheck)
+    m_chamferFloodCheck->setVisible(!adv);
+  if (m_partFloodCheck)
+    m_partFloodCheck->setVisible(!adv);
 
   if (adv && m_materialManager) {
     QString materialName = getSelectedMaterialName();
@@ -1166,12 +1254,24 @@ void SetupConfigurationPanel::updateAdvancedMode() {
     }
     CuttingParameters cp = m_materialManager->calculateCuttingParameters(
         materialName, 10.0, "facing", finishVal);
-    if (m_contourDepthSpin)
-      m_contourDepthSpin->setValue(cp.depthOfCut);
-    if (m_contourFeedSpin)
-      m_contourFeedSpin->setValue(cp.feedRate);
-    if (m_contourSpeedSpin)
-      m_contourSpeedSpin->setValue(cp.spindleSpeed);
+    if (m_contourFacingDepthSpin)
+      m_contourFacingDepthSpin->setValue(cp.depthOfCut);
+    if (m_contourFacingFeedSpin)
+      m_contourFacingFeedSpin->setValue(cp.feedRate);
+    if (m_contourFacingSpeedSpin)
+      m_contourFacingSpeedSpin->setValue(cp.spindleSpeed);
+    if (m_contourRoughDepthSpin)
+      m_contourRoughDepthSpin->setValue(cp.depthOfCut);
+    if (m_contourRoughFeedSpin)
+      m_contourRoughFeedSpin->setValue(cp.feedRate);
+    if (m_contourRoughSpeedSpin)
+      m_contourRoughSpeedSpin->setValue(cp.spindleSpeed);
+    if (m_contourFinishDepthSpin)
+      m_contourFinishDepthSpin->setValue(cp.depthOfCut);
+    if (m_contourFinishFeedSpin)
+      m_contourFinishFeedSpin->setValue(cp.feedRate);
+    if (m_contourFinishSpeedSpin)
+      m_contourFinishSpeedSpin->setValue(cp.spindleSpeed);
   }
 }
 


### PR DESCRIPTION
## Summary
- expose separate advanced settings for facing, roughing and finishing
- add advanced parting parameters with retract modes
- allow enabling flood coolant per operation in simple mode
- update chamfer table to use new chamfer type terminology
- document new advanced options

## Testing
- `cmake .. -DCMAKE_BUILD_TYPE=Debug` *(fails: Qt6 not found)*

------
https://chatgpt.com/codex/tasks/task_e_68505f930c888332a47a298b144164ec