### PR TITLE
Add edge/face management slots

### DIFF
--- a/gui/include/setupconfigurationpanel.h
+++ b/gui/include/setupconfigurationpanel.h
@@ -16,6 +16,7 @@
 #include <QTabWidget>
 #include <QTableWidget>
 #include <QTextEdit>
+#include <QVector>
 #include <QVBoxLayout>
 #include <QWidget>
 
@@ -58,6 +59,19 @@ struct OperationConfig {
   QString name;
   QString description;
   QStringList parameters;
+};
+
+struct ThreadFaceConfig {
+  QString faceId;
+  QString preset;
+  double pitch = 1.0;
+};
+
+struct ChamferFaceConfig {
+  QString faceId;
+  bool symmetric = true;
+  double valueA = 0.5;
+  double valueB = 0.5;
 };
 
 class SetupConfigurationPanel : public QWidget {
@@ -125,6 +139,8 @@ signals:
   void automaticToolpathGenerationRequested();
   void materialSelectionChanged(const QString &materialName);
   void toolRecommendationsUpdated(const QStringList &toolIds);
+  void threadFaceSelected(const QString &faceId);
+  void chamferFaceSelected(const QString &faceId);
 
 public slots:
   void onBrowseStepFile();
@@ -133,6 +149,12 @@ public slots:
   void onOperationToggled();
   void onMaterialChanged();
   void onToolSelectionRequested();
+  void onAddThreadFace();
+  void onRemoveThreadFace();
+  void onAddChamferFace();
+  void onRemoveChamferFace();
+  void onThreadFaceRowSelected();
+  void onChamferFaceRowSelected();
 
 private:
   void setupUI();
@@ -217,6 +239,10 @@ private:
   QPushButton *m_removeChamferFaceButton;
   QDoubleSpinBox *m_extraChamferStockSpin;
   QDoubleSpinBox *m_chamferDiameterLeaveSpin;
+
+  // Stored face/edge configurations
+  QVector<ThreadFaceConfig> m_threadFaces;
+  QVector<ChamferFaceConfig> m_chamferFaces;
 
   // Legacy placeholders to preserve binary compatibility
   QGroupBox *m_operationsGroup;

--- a/gui/src/setupconfigurationpanel.cpp
+++ b/gui/src/setupconfigurationpanel.cpp
@@ -655,10 +655,22 @@ void SetupConfigurationPanel::setupConnections() {
   if (m_threadingEnabledCheck) {
     connect(m_threadingEnabledCheck, &QCheckBox::toggled, this,
             &SetupConfigurationPanel::onOperationToggled);
+    connect(m_addThreadFaceButton, &QPushButton::clicked, this,
+            &SetupConfigurationPanel::onAddThreadFace);
+    connect(m_removeThreadFaceButton, &QPushButton::clicked, this,
+            &SetupConfigurationPanel::onRemoveThreadFace);
+    connect(m_threadFacesTable, &QTableWidget::itemSelectionChanged, this,
+            &SetupConfigurationPanel::onThreadFaceRowSelected);
   }
   if (m_chamferingEnabledCheck) {
     connect(m_chamferingEnabledCheck, &QCheckBox::toggled, this,
             &SetupConfigurationPanel::onOperationToggled);
+    connect(m_addChamferFaceButton, &QPushButton::clicked, this,
+            &SetupConfigurationPanel::onAddChamferFace);
+    connect(m_removeChamferFaceButton, &QPushButton::clicked, this,
+            &SetupConfigurationPanel::onRemoveChamferFace);
+    connect(m_chamferFacesTable, &QTableWidget::itemSelectionChanged, this,
+            &SetupConfigurationPanel::onChamferFaceRowSelected);
   }
   if (m_partingEnabledCheck) {
     connect(m_partingEnabledCheck, &QCheckBox::toggled, this,
@@ -1187,6 +1199,74 @@ void SetupConfigurationPanel::focusOperationTab(const QString &operationName) {
     index = 3;
   if (m_operationsTabWidget)
     m_operationsTabWidget->setCurrentIndex(index);
+}
+
+void SetupConfigurationPanel::onAddThreadFace() {
+  int row = m_threadFacesTable->rowCount();
+  m_threadFacesTable->insertRow(row);
+  m_threadFacesTable->setItem(row, 0, new QTableWidgetItem(tr("Face %1").arg(row + 1)));
+  m_threadFacesTable->setItem(row, 1, new QTableWidgetItem("Default"));
+  m_threadFacesTable->setItem(row, 2, new QTableWidgetItem(QString::number(m_threadPitchSpin->value(), 'f', 2)));
+
+  ThreadFaceConfig cfg;
+  cfg.faceId = QString::number(row);
+  cfg.preset = "Default";
+  cfg.pitch = m_threadPitchSpin->value();
+  m_threadFaces.append(cfg);
+}
+
+void SetupConfigurationPanel::onRemoveThreadFace() {
+  QList<QTableWidgetSelectionRange> ranges = m_threadFacesTable->selectedRanges();
+  if (ranges.isEmpty())
+    return;
+  int row = ranges.first().topRow();
+  m_threadFacesTable->removeRow(row);
+  if (row >= 0 && row < m_threadFaces.size())
+    m_threadFaces.remove(row);
+}
+
+void SetupConfigurationPanel::onAddChamferFace() {
+  int row = m_chamferFacesTable->rowCount();
+  m_chamferFacesTable->insertRow(row);
+  m_chamferFacesTable->setItem(row, 0, new QTableWidgetItem(tr("Face %1").arg(row + 1)));
+  m_chamferFacesTable->setItem(row, 1, new QTableWidgetItem("Yes"));
+  m_chamferFacesTable->setItem(row, 2, new QTableWidgetItem(QString::number(m_chamferSizeSpin->value(), 'f', 2)));
+  m_chamferFacesTable->setItem(row, 3, new QTableWidgetItem(QString::number(m_chamferSizeSpin->value(), 'f', 2)));
+
+  ChamferFaceConfig cfg;
+  cfg.faceId = QString::number(row);
+  cfg.symmetric = true;
+  cfg.valueA = m_chamferSizeSpin->value();
+  cfg.valueB = m_chamferSizeSpin->value();
+  m_chamferFaces.append(cfg);
+}
+
+void SetupConfigurationPanel::onRemoveChamferFace() {
+  QList<QTableWidgetSelectionRange> ranges = m_chamferFacesTable->selectedRanges();
+  if (ranges.isEmpty())
+    return;
+  int row = ranges.first().topRow();
+  m_chamferFacesTable->removeRow(row);
+  if (row >= 0 && row < m_chamferFaces.size())
+    m_chamferFaces.remove(row);
+}
+
+void SetupConfigurationPanel::onThreadFaceRowSelected() {
+  QList<QTableWidgetSelectionRange> ranges = m_threadFacesTable->selectedRanges();
+  if (ranges.isEmpty())
+    return;
+  int row = ranges.first().topRow();
+  if (row >= 0 && row < m_threadFaces.size())
+    emit threadFaceSelected(m_threadFaces[row].faceId);
+}
+
+void SetupConfigurationPanel::onChamferFaceRowSelected() {
+  QList<QTableWidgetSelectionRange> ranges = m_chamferFacesTable->selectedRanges();
+  if (ranges.isEmpty())
+    return;
+  int row = ranges.first().topRow();
+  if (row >= 0 && row < m_chamferFaces.size())
+    emit chamferFaceSelected(m_chamferFaces[row].faceId);
 }
 
 // Utility method implementations


### PR DESCRIPTION
## Summary
- extend `SetupConfigurationPanel` with data structures for threading and chamfering selections
- hook up add/remove buttons and table selection signals
- store per-face settings in vectors and emit selection signals

## Testing
- `cmake -B build -S .` *(fails: Could not find Qt6Config.cmake)*

------
https://chatgpt.com/codex/tasks/task_e_685060b2aaa8833291f9003b422b6b9a