### PR TITLE
Display raw material length

### DIFF
--- a/gui/include/setupconfigurationpanel.h
+++ b/gui/include/setupconfigurationpanel.h
@@ -176,7 +176,7 @@ private:
   QHBoxLayout *m_rawDiameterLayout;
   QLabel *m_rawDiameterLabel;
   QDoubleSpinBox *m_rawDiameterSpin;
-  QLabel *m_rawLengthLabel; // Now just a label showing auto-calculated length
+  QLabel *m_rawLengthLabel; // Displays current raw material length
 
   // Machining Tab Components (Machining Parameters + Operations + Quality)
   QGroupBox *m_machiningParamsGroup;

--- a/gui/src/mainwindow.cpp
+++ b/gui/src/mainwindow.cpp
@@ -1623,7 +1623,17 @@ void MainWindow::handleManualAxisSelected(double diameter, const gp_Ax1& axis)
 
 void MainWindow::handleRawMaterialCreated(double diameter, double length)
 {
-    // Placeholder
+    if (m_setupConfigPanel) {
+        m_setupConfigPanel->updateRawMaterialLength(length);
+    }
+
+    statusBar()->showMessage(tr("Raw material length: %1 mm").arg(length), 2000);
+
+    if (m_outputWindow) {
+        m_outputWindow->append(QString("Raw material created - diameter: %1 mm, length: %2 mm")
+                                   .arg(diameter)
+                                   .arg(length));
+    }
 }
 
 // Part loading panel handlers

--- a/gui/src/setupconfigurationpanel.cpp
+++ b/gui/src/setupconfigurationpanel.cpp
@@ -259,8 +259,8 @@ void SetupConfigurationPanel::setupPartTab() {
   m_rawDiameterLayout->addStretch();
   m_materialLayout->addLayout(m_rawDiameterLayout);
 
-  // Raw material length (auto-calculated, display only)
-  m_rawLengthLabel = new QLabel("Raw Length: Auto-calculated");
+  // Raw material length display
+  m_rawLengthLabel = new QLabel("Raw material length required: 0.0 mm");
   m_rawLengthLabel->setStyleSheet("color: #666; font-size: 11px;");
   m_materialLayout->addWidget(m_rawLengthLabel);
 
@@ -813,7 +813,7 @@ void SetupConfigurationPanel::setOrientationFlipped(bool flipped) {
 
 void SetupConfigurationPanel::updateRawMaterialLength(double length) {
   m_rawLengthLabel->setText(
-      QString("Raw Length: %1 mm (auto-calculated)").arg(length, 0, 'f', 1));
+      QString("Raw material length required: %1 mm").arg(length, 0, 'f', 1));
 }
 
 void SetupConfigurationPanel::setFacingAllowance(double allowance) {


### PR DESCRIPTION
## Summary
- show raw material length on startup
- keep the label updated whenever raw stock is created

## Testing
- `ctest --output-on-failure`

------
https://chatgpt.com/codex/tasks/task_e_68506141f5d08332bf5fc2af1d5d93ef