### PR TITLE
Remove finishing passes and parting width from contouring parameters

### DIFF
--- a/docs/toolpath_workflow.md
+++ b/docs/toolpath_workflow.md
@@ -29,7 +29,7 @@ These settings are dedicated to lathe turning and are independent for every step
 
 ### Simple vs Advanced Mode
 
-The setup panel now offers a checkbox labeled **Advanced Mode**. When disabled, only the most important parameters are shown for each operation. For example, Contouring displays just the facing allowance, number of finishing passes and the final surface finish. Threading and Chamfering list the selected faces in tables where you can add or remove entries and adjust individual parameters.
+The setup panel now offers a checkbox labeled **Advanced Mode**. When disabled, only the most important parameters are shown for each operation. For example, Contouring displays just the facing allowance and the final surface finish. Threading and Chamfering list the selected faces in tables where you can add or remove entries and adjust individual parameters.
 
 Enabling **Advanced Mode** reveals additional controls such as calculated cutting depth, feed rate and spindle speed. These values are pre‑filled from the material database but can be fine‑tuned manually.
 

--- a/gui/include/setupconfigurationpanel.h
+++ b/gui/include/setupconfigurationpanel.h
@@ -227,9 +227,6 @@ private:
   // Advanced mode toggle
   QCheckBox *m_advancedModeCheck;
 
-  // Simplified parameters
-  QSpinBox *m_finishingPassesSpin;
-
   // Threading face table
   QTableWidget *m_threadFacesTable;
   QPushButton *m_addThreadFaceButton;

--- a/gui/src/setupconfigurationpanel.cpp
+++ b/gui/src/setupconfigurationpanel.cpp
@@ -332,18 +332,6 @@ void SetupConfigurationPanel::setupMachiningTab() {
   m_finishingAllowanceLayout->addStretch();
   m_machiningParamsLayout->addLayout(m_finishingAllowanceLayout);
 
-  // Number of finishing passes
-  QHBoxLayout *finishPassLayout = new QHBoxLayout();
-  QLabel *finishPassLabel = new QLabel("Finishing Passes:");
-  finishPassLabel->setMinimumWidth(140);
-  m_finishingPassesSpin = new QSpinBox();
-  m_finishingPassesSpin->setRange(1, 10);
-  m_finishingPassesSpin->setValue(1);
-  finishPassLayout->addWidget(finishPassLabel);
-  finishPassLayout->addWidget(m_finishingPassesSpin);
-  finishPassLayout->addStretch();
-  m_machiningParamsLayout->addLayout(finishPassLayout);
-
   // Flood coolant simple toggle
   QHBoxLayout *coolLayout = new QHBoxLayout();
   m_contourFloodCheck = new QCheckBox("Flood Coolant");
@@ -351,21 +339,6 @@ void SetupConfigurationPanel::setupMachiningTab() {
   coolLayout->addWidget(m_contourFloodCheck);
   coolLayout->addStretch();
   m_machiningParamsLayout->addLayout(coolLayout);
-
-  // Parting width
-  m_partingWidthLayout = new QHBoxLayout();
-  m_partingWidthLabel = new QLabel("Parting Width:");
-  m_partingWidthLabel->setMinimumWidth(140);
-  m_partingWidthSpin = new QDoubleSpinBox();
-  m_partingWidthSpin->setRange(1.0, 5.0);
-  m_partingWidthSpin->setValue(3.0);
-  m_partingWidthSpin->setSuffix(" mm");
-  m_partingWidthSpin->setDecimals(1);
-
-  m_partingWidthLayout->addWidget(m_partingWidthLabel);
-  m_partingWidthLayout->addWidget(m_partingWidthSpin);
-  m_partingWidthLayout->addStretch();
-  m_machiningParamsLayout->addLayout(m_partingWidthLayout);
 
   contourLayout->addWidget(m_machiningParamsGroup);
 


### PR DESCRIPTION
## Summary
- drop finishing pass and parting width controls from contour tab
- clean up header
- update workflow docs

## Testing
- `cmake -S . -B build -GNinja` *(fails: Qt6 not found)*
- `ctest --test-dir build`

------
https://chatgpt.com/codex/tasks/task_e_685062038fa483329cd48127f580163c