### PR TITLE
Update thread face selection workflow

### DIFF
--- a/gui/include/mainwindow.h
+++ b/gui/include/mainwindow.h
@@ -108,6 +108,8 @@ private slots:
     void handleMaterialTypeChanged(IntuiCAM::GUI::MaterialType material);
     void handleRawMaterialDiameterChanged(double diameter);
     void handleManualAxisSelectionRequested();
+    void handleThreadFaceSelectionRequested();
+    void handleThreadFaceSelected(const TopoDS_Shape& face);
     void handleOperationToggled(const QString& operationName, bool enabled);
     void handleAutomaticToolpathGeneration();
     
@@ -201,6 +203,8 @@ private:
     // Material and Tool Management
     IntuiCAM::GUI::MaterialManager *m_materialManager;
     IntuiCAM::GUI::ToolManager *m_toolManager;
+
+    bool m_selectingThreadFace = false;
     
     // Toolpath Generation Controller
     IntuiCAM::GUI::ToolpathGenerationController *m_toolpathGenerationController;

--- a/gui/include/setupconfigurationpanel.h
+++ b/gui/include/setupconfigurationpanel.h
@@ -17,6 +17,7 @@
 #include <QTableWidget>
 #include <QTextEdit>
 #include <QVector>
+#include <TopoDS_Shape.hxx>
 #include <QVBoxLayout>
 #include <QWidget>
 
@@ -62,9 +63,10 @@ struct OperationConfig {
 };
 
 struct ThreadFaceConfig {
-  QString faceId;
+  TopoDS_Shape face;
   QString preset;
   double pitch = 1.0;
+  double depth = 5.0;
 };
 
 struct ChamferFaceConfig {
@@ -139,7 +141,8 @@ signals:
   void automaticToolpathGenerationRequested();
   void materialSelectionChanged(const QString &materialName);
   void toolRecommendationsUpdated(const QStringList &toolIds);
-  void threadFaceSelected(const QString &faceId);
+  void requestThreadFaceSelection();
+  void threadFaceSelected(const TopoDS_Shape &face);
   void chamferFaceSelected(const QString &faceId);
 
 public slots:
@@ -150,10 +153,12 @@ public slots:
   void onMaterialChanged();
   void onToolSelectionRequested();
   void onAddThreadFace();
+  void addSelectedThreadFace(const TopoDS_Shape &face);
   void onRemoveThreadFace();
   void onAddChamferFace();
   void onRemoveChamferFace();
   void onThreadFaceRowSelected();
+  void onThreadFaceCellChanged(int row, int column);
   void onChamferFaceRowSelected();
 
 private:
@@ -265,6 +270,8 @@ private:
   // Stored face/edge configurations
   QVector<ThreadFaceConfig> m_threadFaces;
   QVector<ChamferFaceConfig> m_chamferFaces;
+
+  bool m_updatingThreadTable = false;
   
   // Parting advanced group
   QGroupBox *m_partingAdvancedGroup;
@@ -279,7 +286,6 @@ private:
   QVBoxLayout *m_operationsLayout;
   QCheckBox *m_contouringEnabledCheck;
   QCheckBox *m_threadingEnabledCheck;
-  QDoubleSpinBox *m_threadPitchSpin;
   QCheckBox *m_chamferingEnabledCheck;
   QDoubleSpinBox *m_chamferSizeSpin;
   QCheckBox *m_partingEnabledCheck;


### PR DESCRIPTION
## Summary
- store threading face details with geometry and depth
- request cylindrical face selection from viewer
- highlight selected thread faces in viewer
- update table behavior for presets and custom pitch

## Testing
- `cmake --preset ninja-release` *(fails: Could not find toolchain file)*
- `ctest --preset ninja-release`

------
https://chatgpt.com/codex/tasks/task_e_685065f9715c8332b2ab90550c94363b