### PR TITLE
Compute raw stock from circular edges

### DIFF
--- a/gui/include/workpiecemanager.h
+++ b/gui/include/workpiecemanager.h
@@ -275,6 +275,13 @@ private:
      * @brief Generate description for a detected cylinder
      */
     QString generateCylinderDescription(const CylinderInfo& info, int index);
+
+    /**
+     * @brief Find the largest circular edge diameter on a workpiece
+     * @param workpiece The shape to analyze
+     * @return Largest detected circular edge diameter in mm, or 0.0 if none found
+     */
+    double getLargestCircularEdgeDiameter(const TopoDS_Shape& workpiece) const;
 };
 
-#endif // WORKPIECEMANAGER_H 
+#endif // WORKPIECEMANAGER_H

--- a/gui/src/workspacecontroller.cpp
+++ b/gui/src/workspacecontroller.cpp
@@ -234,8 +234,10 @@ void WorkspaceController::executeWorkpieceWorkflow(const TopoDS_Shape& workpiece
     // Step 5: Position workpiece at requested distance-to-chuck (snap min-Z)
     m_workpieceManager->positionWorkpieceAlongAxis(m_lastDistanceToChuck);
     
-    // Step 6: Calculate optimal raw material size with small margin
-    double marginDiameter = detectedDiameter + 2.0; // add small cleanup allowance
+    // Step 6: Determine raw material diameter based on largest circular edge
+    double edgeDiameter = m_workpieceManager->getLargestCircularEdgeDiameter(workpiece);
+    double marginDiameter = edgeDiameter > 0.0 ? edgeDiameter + 4.0
+                                               : detectedDiameter + 2.0;
     double rawMaterialDiameter = m_rawMaterialManager->getNextStandardDiameter(marginDiameter);
     
     // Step 7: Create and display raw material that encompasses the workpiece


### PR DESCRIPTION
## Summary
- analyze loaded part for circular edges in `WorkpieceManager`
- pick largest edge to determine raw material diameter
- fall back to previous logic when no circular edge detected

## Testing
- `cmake -S . -B build` *(fails: could not find Qt6)*

------
https://chatgpt.com/codex/tasks/task_e_685066875c2c83329d4a542bf934709d