### PR TITLE
Fix part visibility toggle

### DIFF
--- a/gui/include/workpiecemanager.h
+++ b/gui/include/workpiecemanager.h
@@ -236,6 +236,7 @@ signals:
 private:
     Handle(AIS_InteractiveContext) m_context;
     QVector<Handle(AIS_Shape)> m_workpieces;
+    bool m_visible{true};
     
     // Analysis results
     gp_Ax1 m_mainCylinderAxis;

--- a/gui/src/mainwindow.cpp
+++ b/gui/src/mainwindow.cpp
@@ -106,7 +106,7 @@ MainWindow::MainWindow(QWidget *parent)
     m_workspaceController = new WorkspaceController(this);
     m_stepLoader = new StepLoader();
     m_toolpathManager = new ToolpathManager(this);
-    m_workpieceManager = new WorkpieceManager(this);
+    m_workpieceManager = nullptr;  // will be obtained from WorkspaceController
     
     // Create material and tool managers
     m_materialManager = new IntuiCAM::GUI::MaterialManager(this);
@@ -265,8 +265,7 @@ void MainWindow::createCentralWidget()
     // Start on Setup tab (index 1) since that's where the action is
     m_tabWidget->setCurrentIndex(1);
     
-    // Setup all connections after UI components are created
-    setupUiConnections();
+    // Connections will be configured once the workspace is initialized
 }
 
 void MainWindow::createStatusBar()
@@ -428,6 +427,12 @@ void MainWindow::setupWorkspaceConnections()
             if (m_outputWindow) {
                 m_outputWindow->append("Workspace controller initialized successfully");
             }
+
+            // Use the controller's workpiece manager for further interactions
+            m_workpieceManager = m_workspaceController->getWorkpieceManager();
+
+            // Set up UI connections that depend on a valid workpiece manager
+            setupUiConnections();
             
             // Initialize the toolpath generation controller with the same context
             if (m_toolpathGenerationController) {

--- a/gui/src/workpiecemanager.cpp
+++ b/gui/src/workpiecemanager.cpp
@@ -63,8 +63,10 @@ bool WorkpieceManager::addWorkpiece(const TopoDS_Shape& workpiece)
     // Set workpiece material properties
     setWorkpieceMaterial(workpieceAIS);
     
-    // Display the workpiece
-    m_context->Display(workpieceAIS, AIS_Shaded, 0, false);
+    // Display the workpiece only if currently visible
+    if (m_visible) {
+        m_context->Display(workpieceAIS, AIS_Shaded, 0, false);
+    }
     
     // Store the workpiece
     m_workpieces.append(workpieceAIS);
@@ -330,6 +332,8 @@ void WorkpieceManager::clearWorkpieces()
     m_axisAlignmentTransform = gp_Trsf(); // Reset to identity
 
     qDebug() << "All workpieces cleared";
+
+    m_context->UpdateCurrentViewer();
 }
 
 void WorkpieceManager::setWorkpiecesVisible(bool visible)
@@ -338,11 +342,15 @@ void WorkpieceManager::setWorkpiecesVisible(bool visible)
         return;
     }
 
+    m_visible = visible;
+
     for (Handle(AIS_Shape) workpiece : m_workpieces) {
         if (!workpiece.IsNull()) {
             if (visible) {
                 if (!m_context->IsDisplayed(workpiece)) {
                     m_context->Display(workpiece, AIS_Shaded, 0, Standard_False);
+                } else {
+                    m_context->Redisplay(workpiece, Standard_False);
                 }
             } else {
                 m_context->Erase(workpiece, Standard_False);
@@ -403,7 +411,13 @@ bool WorkpieceManager::flipWorkpieceOrientation(bool flipped)
         for (Handle(AIS_Shape) workpiece : m_workpieces) {
             if (!workpiece.IsNull()) {
                 workpiece->SetLocalTransformation(newTransformation);
-                m_context->Redisplay(workpiece, false);
+                if (m_visible) {
+                    if (!m_context->IsDisplayed(workpiece)) {
+                        m_context->Display(workpiece, AIS_Shaded, 0, Standard_False);
+                    } else {
+                        m_context->Redisplay(workpiece, false);
+                    }
+                }
             }
         }
         
@@ -558,7 +572,13 @@ bool WorkpieceManager::positionWorkpieceAlongAxis(double distance)
         for (Handle(AIS_Shape) workpiece : m_workpieces) {
             if (!workpiece.IsNull()) {
                 workpiece->SetLocalTransformation(newTransformation);
-                m_context->Redisplay(workpiece, false);
+                if (m_visible) {
+                    if (!m_context->IsDisplayed(workpiece)) {
+                        m_context->Display(workpiece, AIS_Shaded, 0, Standard_False);
+                    } else {
+                        m_context->Redisplay(workpiece, false);
+                    }
+                }
             }
         }
 
@@ -596,7 +616,13 @@ bool WorkpieceManager::setAxisAlignmentTransformation(const gp_Trsf& transform)
         for (Handle(AIS_Shape) workpiece : m_workpieces) {
             if (!workpiece.IsNull()) {
                 workpiece->SetLocalTransformation(completeTransform);
-                m_context->Redisplay(workpiece, false);
+                if (m_visible) {
+                    if (!m_context->IsDisplayed(workpiece)) {
+                        m_context->Display(workpiece, AIS_Shaded, 0, Standard_False);
+                    } else {
+                        m_context->Redisplay(workpiece, false);
+                    }
+                }
             }
         }
         


### PR DESCRIPTION
## Summary
- remember current visibility state in `WorkpieceManager`
- honour visibility flag when adding and transforming workpieces
- refresh viewer when clearing workpieces
- connect part visibility actions to the active `WorkpieceManager`

## Testing
- `ctest --output-on-failure`


------
https://chatgpt.com/codex/tasks/task_e_68506851b28883328c8b1b57f806a4d6