### PR TITLE
Fix overlay highlight

### DIFF
--- a/gui/src/mainwindow.cpp
+++ b/gui/src/mainwindow.cpp
@@ -2157,6 +2157,8 @@ void MainWindow::highlightThreadCandidateFaces()
         if (surf.GetType() == GeomAbs_Cylinder) {
             TopoDS_Shape global = f.Moved(trsf);
             Handle(AIS_Shape) ais = new AIS_Shape(global);
+            // Keep shape invisible but selectable
+            ais->SetTransparency(1.0);
             ctx->Display(ais, AIS_Shaded, 0, false);
             Handle(Prs3d_Drawer) dr = new Prs3d_Drawer();
             dr->SetColor(Quantity_NOC_LIGHTBLUE);


### PR DESCRIPTION
## Summary
- keep candidate thread faces invisible by setting transparency before highlighting

## Testing
- `cmake -B build` *(fails: Qt6 not found)*

------
https://chatgpt.com/codex/tasks/task_e_68507675713483328904b08490a6f5c4