### PR TITLE
Add toolpath generation button

### DIFF
--- a/gui/include/mainwindow.h
+++ b/gui/include/mainwindow.h
@@ -115,7 +115,7 @@ private slots:
     void handleThreadFaceSelected(const TopoDS_Shape& face);
     void handleWorkpieceTransformed();
     void handleOperationToggled(const QString& operationName, bool enabled);
-    void handleAutomaticToolpathGeneration();
+    void handleGenerateToolpaths();
     
     // 3D viewer handlers
     void handleShapeSelected(const TopoDS_Shape& shape, const gp_Pnt& clickPoint);
@@ -175,6 +175,7 @@ private:
     IntuiCAM::GUI::SetupConfigurationPanel *m_setupConfigPanel;
     OpenGL3DWidget *m_3dViewer;
     ToolpathTimelineWidget *m_toolpathTimeline;
+    QPushButton *m_generateButton;
     QPushButton *m_simulateButton;
     
     // Legacy components (for gradual migration)

--- a/gui/src/toolpathgenerationcontroller.cpp
+++ b/gui/src/toolpathgenerationcontroller.cpp
@@ -457,14 +457,14 @@ bool IntuiCAM::GUI::ToolpathGenerationController::generateOperationToolpaths()
                     }
                 }
                 
-                // Set roughing parameters
+                // Set roughing parameters using request values
                 IntuiCAM::Toolpath::RoughingOperation::Parameters params;
                 params.startDiameter = m_currentRequest.rawDiameter;
-                params.endDiameter = m_currentRequest.rawDiameter * 0.6; // 60% of raw diameter as a simplification
+                params.endDiameter = m_currentRequest.rawDiameter - 2.0 * m_currentRequest.finishingAllowance;
                 params.startZ = 0.0;
-                params.endZ = -50.0; // Arbitrary length for demo
-                params.depthOfCut = 1.0;
-                params.stockAllowance = m_currentRequest.roughingAllowance;
+                params.endZ = -50.0; // placeholder
+                params.depthOfCut = m_currentRequest.roughingAllowance > 0.0 ? m_currentRequest.roughingAllowance : 1.0;
+                params.stockAllowance = m_currentRequest.finishingAllowance;
                 
                 roughingOp->setParameters(params);
                 operation = std::move(roughingOp);
@@ -481,6 +481,7 @@ bool IntuiCAM::GUI::ToolpathGenerationController::generateOperationToolpaths()
                 auto chamferOp = std::make_unique<IntuiCAM::Toolpath::FinishingOperation>(
                     operationName.toStdString(), tool);
                 IntuiCAM::Toolpath::FinishingOperation::Parameters params;
+                params.targetDiameter = m_currentRequest.rawDiameter - 2.0 * m_currentRequest.finishingAllowance;
                 chamferOp->setParameters(params);
                 operation = std::move(chamferOp);
             }
@@ -488,7 +489,8 @@ bool IntuiCAM::GUI::ToolpathGenerationController::generateOperationToolpaths()
                 auto partingOp = std::make_unique<IntuiCAM::Toolpath::PartingOperation>(
                     operationName.toStdString(), tool);
                 IntuiCAM::Toolpath::PartingOperation::Parameters params;
-                params.partingDiameter = m_currentRequest.partingWidth;
+                params.partingDiameter = m_currentRequest.rawDiameter;
+                params.retractDistance = m_currentRequest.partingWidth;
                 partingOp->setParameters(params);
                 operation = std::move(partingOp);
             }


### PR DESCRIPTION
## Summary
- add `Generate Toolpaths` button beside Simulate button
- wire button to new handler to gather parameters from SetupConfigurationPanel
- update ToolpathGenerationController to use request parameters
- ensure toolpaths are displayed in correct position

## Testing
- `cmake ..` *(fails: could not find Qt6)*

------
https://chatgpt.com/codex/tasks/task_e_685081eb9b588332bc1fcde80910094d