### PR TITLE
Fix thread face highlight clearing

### DIFF
--- a/gui/include/mainwindow.h
+++ b/gui/include/mainwindow.h
@@ -248,6 +248,7 @@ private:
     void highlightThreadCandidateFaces();
     void clearThreadCandidateHighlights();
     void updateHighlightedThreadFace();
+    void clearHighlightedThreadFace();
 
     QVector<Handle(AIS_Shape)> m_candidateThreadFaces;
     Handle(AIS_Shape) m_currentThreadFaceAIS;

--- a/gui/include/setupconfigurationpanel.h
+++ b/gui/include/setupconfigurationpanel.h
@@ -143,6 +143,7 @@ signals:
   void toolRecommendationsUpdated(const QStringList &toolIds);
   void requestThreadFaceSelection();
   void threadFaceSelected(const TopoDS_Shape &face);
+  void threadFaceDeselected();
   void chamferFaceSelected(const QString &faceId);
 
 public slots:

--- a/gui/src/mainwindow.cpp
+++ b/gui/src/mainwindow.cpp
@@ -318,6 +318,8 @@ void MainWindow::setupConnections()
                 this, &MainWindow::handleThreadFaceSelectionRequested);
         connect(m_setupConfigPanel, &IntuiCAM::GUI::SetupConfigurationPanel::threadFaceSelected,
                 this, &MainWindow::handleThreadFaceSelected);
+        connect(m_setupConfigPanel, &IntuiCAM::GUI::SetupConfigurationPanel::threadFaceDeselected,
+                this, &MainWindow::clearHighlightedThreadFace);
         if (m_workspaceController) {
             connect(m_workspaceController->getWorkpieceManager(), &WorkpieceManager::workpieceTransformed,
                     this, &MainWindow::handleWorkpieceTransformed);
@@ -2204,6 +2206,18 @@ void MainWindow::updateHighlightedThreadFace()
     dr->SetColor(Quantity_NOC_GREEN);
     dr->SetTransparency(Standard_ShortReal(0.3));
     ctx->HilightWithColor(m_currentThreadFaceAIS, dr, Standard_False);
+    m_3dViewer->update();
+}
+
+void MainWindow::clearHighlightedThreadFace()
+{
+    if (!m_3dViewer || m_currentThreadFaceAIS.IsNull())
+        return;
+
+    Handle(AIS_InteractiveContext) ctx = m_3dViewer->getContext();
+    ctx->Remove(m_currentThreadFaceAIS, Standard_False);
+    m_currentThreadFaceAIS.Nullify();
+    m_currentThreadFaceLocal.Nullify();
     m_3dViewer->update();
 }
 

--- a/gui/src/setupconfigurationpanel.cpp
+++ b/gui/src/setupconfigurationpanel.cpp
@@ -1260,6 +1260,7 @@ void SetupConfigurationPanel::onRemoveThreadFace() {
   m_threadFacesTable->removeRow(row);
   if (row >= 0 && row < m_threadFaces.size())
     m_threadFaces.remove(row);
+  onThreadFaceRowSelected();
 }
 
 void SetupConfigurationPanel::addSelectedThreadFace(const TopoDS_Shape &face) {
@@ -1331,8 +1332,10 @@ void SetupConfigurationPanel::onRemoveChamferFace() {
 
 void SetupConfigurationPanel::onThreadFaceRowSelected() {
   QList<QTableWidgetSelectionRange> ranges = m_threadFacesTable->selectedRanges();
-  if (ranges.isEmpty())
+  if (ranges.isEmpty()) {
+    emit threadFaceDeselected();
     return;
+  }
   int row = ranges.first().topRow();
   if (row >= 0 && row < m_threadFaces.size())
     emit threadFaceSelected(m_threadFaces[row].face);


### PR DESCRIPTION
## Summary
- remove highlight when thread face row is removed or deselected
- add a new `threadFaceDeselected` signal
- handle deselection in `MainWindow` and remove existing highlight

## Testing
- `cmake --preset ninja-release` *(fails: could not find toolchain file)*

------
https://chatgpt.com/codex/tasks/task_e_68508308c2148332bc4de1b26df6a7b3