### PR TITLE
Update raw material auto detection

### DIFF
--- a/gui/include/mainwindow.h
+++ b/gui/include/mainwindow.h
@@ -111,6 +111,7 @@ private slots:
     void handleMaterialTypeChanged(IntuiCAM::GUI::MaterialType material);
     void handleRawMaterialDiameterChanged(double diameter);
     void handleManualAxisSelectionRequested();
+    void handleAutoRawDiameterRequested();
     void handleThreadFaceSelectionRequested();
     void handleThreadFaceSelected(const TopoDS_Shape& face);
     void handleWorkpieceTransformed();

--- a/gui/include/setupconfigurationpanel.h
+++ b/gui/include/setupconfigurationpanel.h
@@ -134,6 +134,7 @@ signals:
   void stepFileSelected(const QString &filePath);
   void materialTypeChanged(MaterialType type);
   void rawMaterialDiameterChanged(double diameter);
+  void autoRawDiameterRequested();
   void distanceToChuckChanged(double distance);
   void orientationFlipped(bool flipped);
   void manualAxisSelectionRequested();
@@ -150,6 +151,7 @@ public slots:
   void onBrowseStepFile();
   void onConfigurationChanged();
   void onManualAxisSelectionClicked();
+  void onAutoRawDiameterClicked();
   void onOperationToggled();
   void onMaterialChanged();
   void onToolSelectionRequested();
@@ -204,6 +206,7 @@ private:
   QHBoxLayout *m_rawDiameterLayout;
   QLabel *m_rawDiameterLabel;
   QDoubleSpinBox *m_rawDiameterSpin;
+  QPushButton *m_autoRawDiameterButton;
   QLabel *m_rawLengthLabel; // Displays current raw material length
 
   // Machining Tab Components (Machining Parameters + Operations + Quality)

--- a/gui/include/workspacecontroller.h
+++ b/gui/include/workspacecontroller.h
@@ -152,6 +152,12 @@ public:
     bool applyPartLoadingSettings(double distance, double diameter, bool flipped);
 
     /**
+     * @brief Calculate recommended raw material diameter from the current part
+     * @return Suggested raw material diameter in mm, or 0.0 if unavailable
+     */
+    double getAutoRawMaterialDiameter() const;
+
+    /**
      * @brief Process manually selected shape from 3D view and extract cylindrical axis
      * @param selectedShape The shape selected in the 3D view
      * @param clickPoint The 3D point where selection occurred

--- a/gui/src/mainwindow.cpp
+++ b/gui/src/mainwindow.cpp
@@ -314,6 +314,8 @@ void MainWindow::setupConnections()
                 this, &MainWindow::handlePartLoadingOrientationFlipped);
         connect(m_setupConfigPanel, &IntuiCAM::GUI::SetupConfigurationPanel::manualAxisSelectionRequested,
                 this, &MainWindow::handleManualAxisSelectionRequested);
+        connect(m_setupConfigPanel, &IntuiCAM::GUI::SetupConfigurationPanel::autoRawDiameterRequested,
+                this, &MainWindow::handleAutoRawDiameterRequested);
         connect(m_setupConfigPanel, &IntuiCAM::GUI::SetupConfigurationPanel::requestThreadFaceSelection,
                 this, &MainWindow::handleThreadFaceSelectionRequested);
         connect(m_setupConfigPanel, &IntuiCAM::GUI::SetupConfigurationPanel::threadFaceSelected,
@@ -1459,6 +1461,26 @@ void MainWindow::handleManualAxisSelectionRequested()
     
     if (m_outputWindow) {
         m_outputWindow->append("Axis selection mode enabled. Please select a cylindrical surface or circular edge in the 3D view.");
+    }
+}
+
+void MainWindow::handleAutoRawDiameterRequested()
+{
+    if (!m_workspaceController || !m_workspaceController->isInitialized()) {
+        return;
+    }
+
+    double diameter = m_workspaceController->getAutoRawMaterialDiameter();
+    if (diameter <= 0.0) {
+        statusBar()->showMessage(tr("Failed to determine raw material diameter"), 3000);
+        return;
+    }
+
+    m_setupConfigPanel->setRawDiameter(diameter);
+    m_workspaceController->updateRawMaterialDiameter(diameter);
+    statusBar()->showMessage(tr("Auto raw diameter set to %1 mm").arg(diameter, 0, 'f', 1), 3000);
+    if (m_outputWindow) {
+        m_outputWindow->append(QString("Auto raw diameter calculated: %1 mm").arg(diameter, 0, 'f', 1));
     }
 }
 

--- a/gui/src/partloadingpanel.cpp
+++ b/gui/src/partloadingpanel.cpp
@@ -378,12 +378,4 @@ void PartLoadingPanel::updateAxisInfo(const CylinderInfo& info)
     
     m_axisInfoLabel->setText(infoText);
 
-    // Auto-set raw material diameter based on part diameter + extra margin
-    if (!m_updating) {
-        m_updating = true;
-        double suggestedDiameter = info.diameter + 10.0; // Add 10mm margin
-        m_rawMaterialDiameterSpinBox->setValue(suggestedDiameter);
-        m_updating = false;
-        emit rawMaterialDiameterChanged(suggestedDiameter);
-    }
 } 

--- a/gui/src/setupconfigurationpanel.cpp
+++ b/gui/src/setupconfigurationpanel.cpp
@@ -253,9 +253,12 @@ void SetupConfigurationPanel::setupPartTab() {
   m_rawDiameterSpin->setValue(50.0);
   m_rawDiameterSpin->setSuffix(" mm");
   m_rawDiameterSpin->setDecimals(1);
+  m_autoRawDiameterButton = new QPushButton("Auto");
+  m_autoRawDiameterButton->setMaximumWidth(60);
 
   m_rawDiameterLayout->addWidget(m_rawDiameterLabel);
   m_rawDiameterLayout->addWidget(m_rawDiameterSpin);
+  m_rawDiameterLayout->addWidget(m_autoRawDiameterButton);
   m_rawDiameterLayout->addStretch();
   m_materialLayout->addLayout(m_rawDiameterLayout);
 
@@ -633,6 +636,8 @@ void SetupConfigurationPanel::setupConnections() {
   connect(m_rawDiameterSpin,
           QOverload<double>::of(&QDoubleSpinBox::valueChanged), this,
           &SetupConfigurationPanel::onConfigurationChanged);
+  connect(m_autoRawDiameterButton, &QPushButton::clicked, this,
+          &SetupConfigurationPanel::onAutoRawDiameterClicked);
 
   // Part positioning connections
   connect(m_distanceSlider, &QSlider::valueChanged, this, [this](int value) {
@@ -921,6 +926,10 @@ void SetupConfigurationPanel::onManualAxisSelectionClicked() {
   emit manualAxisSelectionRequested();
   m_axisInfoLabel->setText("Selection mode enabled - click on a cylindrical "
                            "surface or circular edge in the 3D view");
+}
+
+void SetupConfigurationPanel::onAutoRawDiameterClicked() {
+  emit autoRawDiameterRequested();
 }
 
 void SetupConfigurationPanel::onConfigurationChanged() {


### PR DESCRIPTION
## Summary
- add "Auto" button next to raw diameter spin box and connect slot
- emit `autoRawDiameterRequested` signal
- compute raw stock diameter from largest full circle edge
- hook up automatic raw diameter detection in workflow
- expose helper to get recommended raw diameter
- remove legacy diameter autoset in PartLoadingPanel

## Testing
- `cmake -S . -B build` *(fails: could not find Qt6)*

------
https://chatgpt.com/codex/tasks/task_e_6851ce7ec3148332971cc052c35c9a50