### PR TITLE
Fix lathe zoom centering and drop grid

### DIFF
--- a/docs/gui/coordinate_system_implementation.md
+++ b/docs/gui/coordinate_system_implementation.md
@@ -17,10 +17,8 @@ The following coordinate system improvements have been implemented:
    - Z-axis runs horizontally (positive from right to left)
    - View from negative Y-axis toward origin
 
-3. **Grid Visualization**
-   - Created a grid display for the XZ view to provide visual reference
-   - Grid lines at specified intervals (default 10mm)
-   - Highlighted X and Z axes with distinct colors (X: green, Z: red)
+3. **Grid Visualization (Removed)**
+   - The previous grid overlay for the XZ view has been removed to simplify the interface
 
 4. **Camera State Preservation**
    - 3D camera state is preserved when switching to XZ view
@@ -38,7 +36,6 @@ The following coordinate system improvements have been implemented:
 The implementation involved changes to several key components:
 
 1. **OpenGL3DWidget**
-   - Added methods for creating and displaying a grid in the XZ view
    - Updated camera setup methods to use proper orthographic projection
    - Implemented state preservation between view modes
 
@@ -60,7 +57,7 @@ To switch between coordinate systems:
    - `ViewMode::Mode3D` for standard 3D view
    - `ViewMode::LatheXZ` for lathe 2D view
 
-The view will automatically adjust the projection, grid display, and camera orientation to match the selected mode.
+The view will automatically adjust the projection and camera orientation to match the selected mode.
 
 ## Benefits
 
@@ -68,7 +65,7 @@ This implementation provides several benefits for lathe operations:
 
 1. **Improved accuracy** in measuring and visualizing lathe operations
 2. **Familiar coordinate system** for CNC lathe programmers
-3. **Visual grid references** for easier part dimensioning
+3. **Removed grid overlay** for a cleaner view
 4. **Better depth perception** with true orthographic projection
 5. **Consistent axis orientation** aligned with G-code conventions
 
@@ -76,7 +73,6 @@ This implementation provides several benefits for lathe operations:
 
 Potential future enhancements to consider:
 
-1. Additional grid customization options (spacing, color, etc.)
-2. Measurement tools specific to the lathe view
-3. Dimension display in the XZ view
-4. Enhanced visualization of cutting depth in lathe operations 
+1. Measurement tools specific to the lathe view
+2. Dimension display in the XZ view
+3. Enhanced visualization of cutting depth in lathe operations

--- a/docs/gui/view_modes.md
+++ b/docs/gui/view_modes.md
@@ -28,9 +28,7 @@ IntuiCAM's 3D viewer supports two distinct viewing modes that can be seamlessly 
 - **Features**:
   - True orthographic projection for accurate dimensional representation
   - Proper lathe coordinate system (X+ down, Z+ left)
-  - Reference grid with adjustable spacing (default 10mm)
   - Highlighted X and Z axes (red for Z, green for X)
-  - Grid spacing indicators at regular intervals
   - Enhanced trihedron oriented to match lathe conventions
 
 ## Lathe Coordinate System
@@ -73,14 +71,6 @@ ViewMode currentMode = viewer->getViewMode();
 - 3D Mode: Uses Graphic3d_Camera::Projection_Perspective for realistic depth perception
 - XZ Mode: Uses Graphic3d_Camera::Projection_Orthographic for accurate dimensional representation
 
-### Grid Display
-The XZ view includes a reference grid that helps with:
-- Dimensional estimation
-- Alignment reference
-- Visual cues for scale and orientation
-
-The grid can be customized with different spacing values depending on the workpiece size.
-
 ### State Preservation
 When switching between modes, the 3D camera state is preserved, allowing users to:
 1. Switch to XZ view for precise measurement and toolpath programming
@@ -97,12 +87,6 @@ When switching between modes, the 3D camera state is preserved, allowing users t
 - Explicitly sets `Graphic3d_Camera::Projection_Orthographic` for XZ mode
 - Proper camera positioning and orientation for each mode
 
-### Lathe Grid System
-- 10mm grid spacing for precise measurement reference
-- Extends 200mm in each direction from origin
-- Highlighted axes (X in blue, Z in red) for clear orientation
-- Automatically displayed in lathe mode, hidden in 3D mode
-- Proper memory management with cleanup on widget destruction
 
 ### Event Handling
 - Mouse interaction behavior changes based on current mode
@@ -115,7 +99,6 @@ When switching between modes, the 3D camera state is preserved, allowing users t
 - Status bar messages indicate current mode
 - Output log provides detailed mode information and usage hints
 - Dynamic menu text updates based on current mode
-- Reference grid for precise positioning and measurement
 
 ### Usage Guidance
 When switching to Lathe XZ mode, users receive helpful information:
@@ -150,10 +133,7 @@ class OpenGL3DWidget {
     void store3DCameraState();
     void restore3DCameraState();
     
-    // Grid management
-    void createLatheGrid(double spacing = 10.0, double extent = 200.0);
-    void removeLatheGrid();
-    
+
 signals:
     void viewModeChanged(ViewMode mode);
 };
@@ -186,7 +166,6 @@ signals:
 ### Potential Extensions
 1. **Additional View Modes**: YZ plane, custom oriented planes
 2. **Mode-Specific Tools**: Measurement tools optimized for each mode
-3. **Customizable Grid**: User-configurable grid spacing and color
 4. **Saved Views**: Named camera positions for quick access
 5. **Position Markers**: Origin and machine coordinate system indicators
 
@@ -196,8 +175,6 @@ signals:
 void setCustomViewPlane(const gp_Pln& plane);
 void saveNamedView(const QString& name);
 void restoreNamedView(const QString& name);
-void setGridSpacing(double spacing);
-void setGridVisible(bool visible);
 ```
 
-This documentation covers the comprehensive view mode system that provides both traditional 3D viewing and specialized lathe XZ plane visualization in a single, seamless interface with precise orthographic projection and measurement grid. 
+This documentation covers the comprehensive view mode system that provides both traditional 3D viewing and specialized lathe XZ plane visualization in a single, seamless interface with precise orthographic projection and measurement tools.

--- a/gui/include/opengl3dwidget.h
+++ b/gui/include/opengl3dwidget.h
@@ -236,17 +236,6 @@ private:
      */
     void restore3DCameraState();
 
-    /**
-     * @brief Create and display a grid for the lathe XZ view
-     * @param spacing Spacing between grid lines in mm
-     * @param extent Maximum distance from origin for grid lines
-     */
-    void createLatheGrid(double spacing = 10.0, double extent = 200.0);
-
-    /**
-     * @brief Remove the lathe grid from display
-     */
-    void removeLatheGrid();
 
     // OpenCASCADE handles
     Handle(V3d_Viewer) m_viewer;
@@ -294,12 +283,7 @@ private:
     // Workspace controller
     class WorkspaceController* m_workspaceController;
 
-    // Lathe grid display elements
-    bool m_gridVisible;
-    Standard_Real m_gridSpacing;
-    Standard_Real m_gridExtent;
-    
-    // Grid objects are managed by the AIS context, no need to store references
+    // Grid objects have been removed
 };
 
 #endif // OPENGL3DWIDGET_H 


### PR DESCRIPTION
## Summary
- remove unused lathe grid logic
- simplify wheel zoom logic so view doesn't recenter
- document that the lathe grid overlay was removed

## Testing
- `cmake -S . -B build` *(fails: Could not find a package configuration file provided by "Qt6")*

------
https://chatgpt.com/codex/tasks/task_e_6853d92e93348332b0ccf62cd3d3a196