### PR TITLE
Fix viewer losing focus causing black screen

### DIFF
--- a/gui/include/opengl3dwidget.h
+++ b/gui/include/opengl3dwidget.h
@@ -9,9 +9,6 @@
 #include <QEvent>
 #include <QEnterEvent>
 #include <QPaintEvent>
-#include <QFocusEvent>
-#include <QShowEvent>
-#include <QHideEvent>
 
 // Standard includes
 #include <vector>
@@ -195,14 +192,9 @@ protected:
     void mouseReleaseEvent(QMouseEvent *event) override;
     void wheelEvent(QWheelEvent *event) override;
     
-    // Focus handling for black screen prevention
-    void focusInEvent(QFocusEvent *event) override;
-    void focusOutEvent(QFocusEvent *event) override;
-    void showEvent(QShowEvent *event) override;
-    void hideEvent(QHideEvent *event) override;
-    
-    // Basic QOpenGLWidget lifecycle events are sufficient. Extra overrides
-    // were removed for a leaner and more stable implementation.
+    // Basic QOpenGLWidget lifecycle events are sufficient. Extra overrides were
+    // removed for a leaner and more stable implementation and to avoid black
+    // screens when the widget loses focus.
 
 private:
     /**

--- a/gui/src/main.cpp
+++ b/gui/src/main.cpp
@@ -9,6 +9,11 @@
 
 int main(int argc, char *argv[])
 {
+
+    // Share OpenGL contexts across widgets to prevent black screens when focus
+    // changes. This follows guidelines from Context7 research.
+    QCoreApplication::setAttribute(Qt::AA_ShareOpenGLContexts);
+
     QApplication app(argc, argv);
     
     // CRITICAL: Set global OpenGL surface format BEFORE creating OpenGL widgets

--- a/gui/src/opengl3dwidget.cpp
+++ b/gui/src/opengl3dwidget.cpp
@@ -453,51 +453,7 @@ void OpenGL3DWidget::wheelEvent(QWheelEvent *event)
     }
 }
 
-// CRITICAL: Focus event handling to prevent black screen
-void OpenGL3DWidget::focusInEvent(QFocusEvent *event)
-{
-    QOpenGLWidget::focusInEvent(event);
-    
-    // ESSENTIAL: Ensure proper context when gaining focus
-    if (m_isInitialized && !m_view.IsNull()) {
-        makeCurrent();
-        // Force a redraw to prevent black screen
-        QTimer::singleShot(1, this, [this]() {
-            if (m_isInitialized && !m_view.IsNull()) {
-                makeCurrent();
-                m_view->Redraw();
-            }
-        });
-    }
-}
 
-void OpenGL3DWidget::focusOutEvent(QFocusEvent *event)
-{
-    QOpenGLWidget::focusOutEvent(event);
-    // Don't call doneCurrent() here as it can cause black screen
-}
-
-void OpenGL3DWidget::showEvent(QShowEvent *event)
-{
-    QOpenGLWidget::showEvent(event);
-    
-    // ESSENTIAL: Ensure proper initialization when widget becomes visible
-    if (m_isInitialized && !m_view.IsNull()) {
-        QTimer::singleShot(1, this, [this]() {
-            if (m_isInitialized && !m_view.IsNull()) {
-                makeCurrent();
-                m_view->MustBeResized();
-                m_view->Redraw();
-            }
-        });
-    }
-}
-
-void OpenGL3DWidget::hideEvent(QHideEvent *event)
-{
-    QOpenGLWidget::hideEvent(event);
-    // Don't do anything special here to avoid context issues
-}
 
 void OpenGL3DWidget::setContinuousUpdate(bool enabled)
 {


### PR DESCRIPTION
## Summary
- remove custom focus/show/hide handlers from `OpenGL3DWidget`
- set `Qt::AA_ShareOpenGLContexts` in `main.cpp`
- document that only basic lifecycle events remain in the header

## Testing
- `ctest` *(fails: No test configuration file found)*

------
https://chatgpt.com/codex/tasks/task_e_6853e86746f0833296dde0f2207c7f79