### PR TITLE
Fix viewer black screen on focus loss

### DIFF
--- a/gui/include/opengl3dwidget.h
+++ b/gui/include/opengl3dwidget.h
@@ -195,7 +195,7 @@ protected:
     void mouseReleaseEvent(QMouseEvent *event) override;
     void wheelEvent(QWheelEvent *event) override;
     
-    // Focus handling - use update() on focus changes to avoid black screens
+    // Focus handling - call update() on focus changes to avoid black screens
     void focusInEvent(QFocusEvent *event) override;
     void focusOutEvent(QFocusEvent *event) override;
     void showEvent(QShowEvent *event) override;

--- a/gui/src/opengl3dwidget.cpp
+++ b/gui/src/opengl3dwidget.cpp
@@ -473,6 +473,13 @@ void OpenGL3DWidget::focusInEvent(QFocusEvent *event)
 void OpenGL3DWidget::focusOutEvent(QFocusEvent *event)
 {
     QOpenGLWidget::focusOutEvent(event);
+    // Schedule a repaint when focus is lost to ensure the framebuffer remains
+    // valid. Qt's documentation recommends calling update() when a repaint is
+    // needed outside of paintGL(). This avoids the viewer turning black when
+    // interacting with other widgets.
+    if (m_isInitialized && !m_view.IsNull()) {
+        update();
+    }
     // Don't call doneCurrent() here as it can cause black screen
 }
 


### PR DESCRIPTION
## Summary
- update OpenGL3DWidget when focus is lost
- clarify comment about focus handling

## Testing
- `cmake --preset ninja-release` *(fails: Could not find toolchain file)*

------
https://chatgpt.com/codex/tasks/task_e_6853f20f40d48332bf1ef6b00fe08bd7