### PR TITLE
Fix toolpath generation prechecks

### DIFF
--- a/gui/src/mainwindow.cpp
+++ b/gui/src/mainwindow.cpp
@@ -1525,9 +1525,6 @@ void MainWindow::handleOperationToggled(const QString& operationName, bool enabl
 
 void MainWindow::handleGenerateToolpaths()
 {
-    // IMMEDIATE CRASH TEST - Show message box to confirm method is called
-    QMessageBox::information(this, "Debug", "handleGenerateToolpaths() called!");
-    
     // Add extensive debugging to identify crash location
     if (m_outputWindow) {
         m_outputWindow->append("=== DEBUG: Starting handleGenerateToolpaths() ===");
@@ -1544,6 +1541,16 @@ void MainWindow::handleGenerateToolpaths()
     
     if (m_outputWindow) {
         m_outputWindow->append("DEBUG: ToolpathGenerationController available");
+    }
+
+    // Avoid launching a new generation process while one is already active
+    if (m_toolpathGenerationController->getStatus() !=
+        IntuiCAM::GUI::ToolpathGenerationController::GenerationStatus::Idle) {
+        statusBar()->showMessage("Toolpath generation already in progress", 3000);
+        if (m_outputWindow) {
+            m_outputWindow->append("WARNING: Generation already running");
+        }
+        return;
     }
     
     if (!m_workspaceController) {

--- a/gui/src/toolpathgenerationcontroller.cpp
+++ b/gui/src/toolpathgenerationcontroller.cpp
@@ -163,6 +163,11 @@ void IntuiCAM::GUI::ToolpathGenerationController::generateToolpaths(const Genera
         emit errorOccurred("Generation already in progress. Please wait or cancel current operation.");
         return;
     }
+
+    if (!m_toolpathManager) {
+        emit errorOccurred("Toolpath manager not initialized");
+        return;
+    }
     
     // Store the request and cache parameters
     m_currentRequest = request;


### PR DESCRIPTION
## Summary
- remove debug message box
- prevent starting toolpath generation if one is already active
- check for missing toolpath manager before starting generation

## Testing
- `cmake ..` *(fails: Could not find a package configuration file provided by "Qt6")*

------
https://chatgpt.com/codex/tasks/task_e_68543c8eca4c833283d014e3f431c57e