### PR TITLE
Fix duplicate toolpath generation button connection

### DIFF
--- a/gui/src/mainwindow.cpp
+++ b/gui/src/mainwindow.cpp
@@ -985,9 +985,6 @@ QWidget* MainWindow::createSetupTab()
     m_propertiesPanel = new QTextEdit;
     m_propertiesPanel->hide();
     
-    // Connect generation and simulation buttons
-    connect(m_generateButton, &QPushButton::clicked, this, &MainWindow::handleGenerateToolpaths);
-    connect(m_simulateButton, &QPushButton::clicked, this, &MainWindow::simulateToolpaths);
     
     // Connect export button
     connect(exportButton, &QPushButton::clicked, [this]() {


### PR DESCRIPTION
## Summary
- fix duplicate button connections in setup tab

## Testing
- `ctest --output-on-failure` *(fails: No tests were found)*

------
https://chatgpt.com/codex/tasks/task_e_6855382eb5f48332b4049bb22d570957