### PR TITLE
Align default 3D view to lathe orientation

### DIFF
--- a/docs/gui/coordinate_system_implementation.md
+++ b/docs/gui/coordinate_system_implementation.md
@@ -1,4 +1,4 @@
-# Lathe Coordinate System Implementation
+#Lathe Coordinate System Implementation
 
 ## Overview
 
@@ -17,16 +17,19 @@ The following coordinate system improvements have been implemented:
    - Z-axis runs horizontally (positive from right to left)
    - View from negative Y-axis toward origin
 
-3. **Grid Visualization (Removed)**
+3. **Lathe-Oriented Default 3D View**
+   - The initial 3D camera now positions the Z axis horizontally, matching the lathe orientation
+
+4. **Grid Visualization (Removed)**
    - The previous grid overlay for the XZ view has been removed to simplify the interface
 
-4. **Camera State Preservation**
+5. **Camera State Preservation**
    - 3D camera state is preserved when switching to XZ view
    - Projection type (perspective or orthographic) is restored when returning to 3D view
    - XZ view settings are consistent with standard lathe conventions
    - Smooth transition between views with proper handling of different projection types
 
-5. **Proper Cleanup and Redisplay**
+6. **Proper Cleanup and Redisplay**
    - Added support for removing and redisplaying objects when switching views
    - Implemented helper methods in all managers to support redisplay operations
    - Efficient handling of object transforms and materials

--- a/gui/src/opengl3dwidget.cpp
+++ b/gui/src/opengl3dwidget.cpp
@@ -723,25 +723,27 @@ void OpenGL3DWidget::setupCamera3D()
     }
     
     try {
-        // Restore previous 3D camera state if available
-        if (m_has3DCameraState) {
-            restore3DCameraState();
-        } else {
-            // Set up default 3D perspective view
-            m_view->SetAt(0.0, 0.0, 0.0);
-            m_view->SetEye(100.0, 100.0, 100.0);
-            m_view->SetUp(0.0, 0.0, 1.0);
-            
-            // Explicitly set perspective projection for 3D mode
-            m_view->Camera()->SetProjectionType(Graphic3d_Camera::Projection_Perspective);
-            
-            // Ensure the view shows the coordinate trihedron
-            m_view->TriedronDisplay(Aspect_TOTP_LEFT_LOWER, Quantity_NOC_GOLD, 0.08, V3d_ZBUFFER);
-            
-            // Update the current view mode
-            m_currentViewMode = ViewMode::Mode3D;
-        }
-        
+      // Restore previous 3D camera state if available
+      if (m_has3DCameraState) {
+        restore3DCameraState();
+      } else {
+        // Set up default 3D perspective view with Z axis horizontal
+        m_view->SetAt(0.0, 0.0, 0.0);
+        m_view->SetEye(200.0, -300.0, 0.0);
+        m_view->SetUp(-1.0, 0.0, 0.0);
+
+        // Explicitly set perspective projection for 3D mode
+        m_view->Camera()->SetProjectionType(
+            Graphic3d_Camera::Projection_Perspective);
+
+        // Ensure the view shows the coordinate trihedron
+        m_view->TriedronDisplay(Aspect_TOTP_LEFT_LOWER, Quantity_NOC_GOLD, 0.08,
+                                V3d_ZBUFFER);
+
+        // Update the current view mode
+        m_currentViewMode = ViewMode::Mode3D;
+      }
+
         // Fit all to ensure objects are visible
         m_view->FitAll();
         m_view->Redraw();


### PR DESCRIPTION
## Summary
- orient the 3D camera so the Z axis is horizontal by default
- document the new startup orientation in the coordinate system docs

## Testing
- `cmake --preset ninja-release` *(fails: Could not find toolchain file)*
- `ctest --preset ninja-release` *(fails: No tests were found)*

------
https://chatgpt.com/codex/tasks/task_e_68553c4e9a9c8332b10aaa198b9b76f5