### PR TITLE
Enable minimal Codex build

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -137,3 +137,4 @@ __pycache__/
 *.zip
 *.7z
 *.rar
+test_core

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -18,35 +18,42 @@ if(NOT DEFINED CMAKE_PREFIX_PATH)
   set(CMAKE_PREFIX_PATH "")
 endif()
 
-list(APPEND CMAKE_PREFIX_PATH "C:/Qt/6.9.0/msvc2022_64")
-list(APPEND CMAKE_PREFIX_PATH "C:/OpenCASCADE/3rdparty-vc14-64/vtk-9.4.1-x64/lib/cmake/vtk-9.4")
-list(APPEND CMAKE_PREFIX_PATH "C:/OpenCASCADE/occt-vc144-64-with-debug/cmake")
+if(WIN32)
+  # Windows development environment uses preinstalled dependencies
+  list(APPEND CMAKE_PREFIX_PATH "C:/Qt/6.9.0/msvc2022_64")
+  list(APPEND CMAKE_PREFIX_PATH "C:/OpenCASCADE/3rdparty-vc14-64/vtk-9.4.1-x64/lib/cmake/vtk-9.4")
+  list(APPEND CMAKE_PREFIX_PATH "C:/OpenCASCADE/occt-vc144-64-with-debug/cmake")
 
-# Add EGL and other 3rdparty library paths
-link_directories("C:/OpenCASCADE/3rdparty-vc14-64/angle-gles2-2.1.0-vc14-64/lib")
-link_directories("C:/OpenCASCADE/3rdparty-vc14-64/draco-1.4.1-vc14-64/lib")
-link_directories("C:/OpenCASCADE/3rdparty-vc14-64/jemalloc-vc14-64/lib")
-link_directories("C:/OpenCASCADE/3rdparty-vc14-64/openvr-1.14.15-64/lib/win64")
-link_directories("C:/OpenCASCADE/3rdparty-vc14-64/freeimage-3.18.0-x64/lib")
-link_directories("C:/OpenCASCADE/3rdparty-vc14-64/ffmpeg-3.3.4-64/lib")
-link_directories("C:/OpenCASCADE/3rdparty-vc14-64/freetype-2.13.3-x64/lib")
-link_directories("C:/OpenCASCADE/3rdparty-vc14-64/tbb-2021.13.0-x64/lib")
-link_directories("C:/OpenCASCADE/3rdparty-vc14-64/tcltk-8.6.15-x64/lib")
+  # Add EGL and other 3rdparty library paths
+  link_directories("C:/OpenCASCADE/3rdparty-vc14-64/angle-gles2-2.1.0-vc14-64/lib")
+  link_directories("C:/OpenCASCADE/3rdparty-vc14-64/draco-1.4.1-vc14-64/lib")
+  link_directories("C:/OpenCASCADE/3rdparty-vc14-64/jemalloc-vc14-64/lib")
+  link_directories("C:/OpenCASCADE/3rdparty-vc14-64/openvr-1.14.15-64/lib/win64")
+  link_directories("C:/OpenCASCADE/3rdparty-vc14-64/freeimage-3.18.0-x64/lib")
+  link_directories("C:/OpenCASCADE/3rdparty-vc14-64/ffmpeg-3.3.4-64/lib")
+  link_directories("C:/OpenCASCADE/3rdparty-vc14-64/freetype-2.13.3-x64/lib")
+  link_directories("C:/OpenCASCADE/3rdparty-vc14-64/tbb-2021.13.0-x64/lib")
+  link_directories("C:/OpenCASCADE/3rdparty-vc14-64/tcltk-8.6.15-x64/lib")
 
-# Add OpenCASCADE library paths
-link_directories("C:/OpenCASCADE/occt-vc144-64-with-debug/win64/vc14/lib")
-link_directories("C:/OpenCASCADE/occt-vc144-64-with-debug/win64/vc14/libd")
+  # Add OpenCASCADE library paths
+  link_directories("C:/OpenCASCADE/occt-vc144-64-with-debug/win64/vc14/lib")
+  link_directories("C:/OpenCASCADE/occt-vc144-64-with-debug/win64/vc14/libd")
+endif()
 
 # Find Qt6 with components
 find_package(Qt6 REQUIRED COMPONENTS Core Gui Widgets OpenGL OpenGLWidgets)
 qt_standard_project_setup()
 
 # Find VTK first (required by OpenCASCADE)
-set(VTK_DIR "C:/OpenCASCADE/3rdparty-vc14-64/vtk-9.4.1-x64/lib/cmake/vtk-9.4")
+if(WIN32)
+  set(VTK_DIR "C:/OpenCASCADE/3rdparty-vc14-64/vtk-9.4.1-x64/lib/cmake/vtk-9.4")
+endif()
 find_package(VTK REQUIRED)
 
 # Set up OpenCASCADE
-set(OpenCASCADE_DIR "C:/OpenCASCADE/occt-vc144-64-with-debug/cmake")
+if(WIN32)
+  set(OpenCASCADE_DIR "C:/OpenCASCADE/occt-vc144-64-with-debug/cmake")
+endif()
 find_package(OpenCASCADE REQUIRED)
 
 # Fix hardcoded jemalloc path issue in OpenCASCADE configuration

--- a/codex_run.sh
+++ b/codex_run.sh
@@ -1,0 +1,10 @@
+#!/bin/bash
+# Minimal build script for the Codex environment
+set -e
+
+# Compile a lightweight test binary without external dependencies
+
+g++ tests/test_core.cpp -Icore/common/include -Icore/geometry/include -std=c++17 -o test_core
+
+# Run the binary to verify that the basic headers compile
+./test_core


### PR DESCRIPTION
## Summary
- wrap Windows-specific paths in `CMakeLists.txt` so Linux builds don't fail
- add `codex_run.sh` script that builds and runs the lightweight core test
- ignore the generated `test_core` binary

## Testing
- `./codex_run.sh`

------
https://chatgpt.com/codex/tasks/task_e_68554b037600833280d5227da06792de