### PR TITLE
Fix toolpath display initialization

### DIFF
--- a/gui/src/mainwindow.cpp
+++ b/gui/src/mainwindow.cpp
@@ -420,6 +420,12 @@ void MainWindow::setupWorkspaceConnections()
         
         if (!context.IsNull()) {
             m_workspaceController->initialize(context, m_stepLoader);
+            if (m_toolpathManager) {
+                m_toolpathManager->initialize(context);
+                if (m_outputWindow) {
+                    m_outputWindow->append("Toolpath manager initialized successfully");
+                }
+            }
             if (m_outputWindow) {
                 m_outputWindow->append("Workspace controller initialized successfully");
             }
@@ -2195,6 +2201,12 @@ void MainWindow::initializeWorkspace()
         
         if (!context.IsNull()) {
             m_workspaceController->initialize(context, m_stepLoader);
+            if (m_toolpathManager) {
+                m_toolpathManager->initialize(context);
+                if (m_outputWindow) {
+                    m_outputWindow->append("Toolpath manager initialized successfully");
+                }
+            }
             if (m_outputWindow) {
                 m_outputWindow->append("Workspace controller initialized successfully");
             }


### PR DESCRIPTION
## Summary
- initialize `ToolpathManager` with the OpenCASCADE context when the workspace is set up
- log initialization of the toolpath manager for debugging

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_68554fbe8f58833287e251c1aeaaee1e