### PR TITLE
Fix workspace initialization timing

### DIFF
--- a/gui/src/mainwindow.cpp
+++ b/gui/src/mainwindow.cpp
@@ -131,7 +131,12 @@ MainWindow::MainWindow(QWidget *parent)
     setWindowTitle(tr("IntuiCAM - Computer Aided Manufacturing"));
     resize(1280, 800);
     
-    // Initialize workspace automatically after a short delay to ensure OpenGL is ready
+    // Initialize the workspace once the OpenGL viewer is ready
+    connect(m_3dViewer, &OpenGL3DWidget::viewerInitialized,
+            this, &MainWindow::initializeWorkspace);
+
+    // Fallback initialization in case the signal was emitted before the
+    // connection or the viewer initializes instantly
     QTimer::singleShot(100, this, &MainWindow::initializeWorkspace);
 }
 


### PR DESCRIPTION
## Summary
- connect viewerInitialized signal to initializeWorkspace
- keep timer as fallback

## Testing
- `cmake -B build -S . -DCMAKE_BUILD_TYPE=Debug` *(fails: Qt6Config.cmake not found)*
- `ctest --output-on-failure` *(no tests found)*

------
https://chatgpt.com/codex/tasks/task_e_685553c5d65c8332bbb6b65bc9e98112