### PR TITLE
Stop switching to simulation tab automatically

### DIFF
--- a/gui/src/mainwindow.cpp
+++ b/gui/src/mainwindow.cpp
@@ -1674,12 +1674,9 @@ void MainWindow::handleGenerateToolpaths()
                 }
             }
             
-            // Step 11: Switch to simulation tab to show results
-            if (m_tabWidget) {
-                m_tabWidget->setCurrentIndex(2); // Switch to simulation tab
-                if (m_outputWindow) {
-                    m_outputWindow->append("Switched to Simulation tab for review");
-                }
+            // Step 11: Inform user that simulation preview is available
+            if (m_outputWindow) {
+                m_outputWindow->append("Toolpath generation complete - switch to the Simulation tab to review");
             }
             
         } else {


### PR DESCRIPTION
## Summary
- avoid switching to the Simulation tab right after toolpath generation
- notify the user that the simulation preview is available instead

## Testing
- `ctest --output-on-failure`
- `cmake -S . -B build` *(fails: Qt6 not found)*

------
https://chatgpt.com/codex/tasks/task_e_68584068542083328bc5fc41260533d6