### PR TITLE
Fix double-click opening two dialog windows

### DIFF
--- a/gui/src/toolmanagementtab.cpp
+++ b/gui/src/toolmanagementtab.cpp
@@ -419,7 +419,6 @@ void ToolManagementTab::onToolListDoubleClicked() {
     if (currentItem) {
         QString toolId = currentItem->text(COL_NAME);
         emit toolDoubleClicked(toolId);
-        editSelectedTool();
     }
 }
 


### PR DESCRIPTION
## Summary
- fix double click behavior in tool tab to emit signal only

## Testing
- `cmake --preset ninja-release` *(fails: could not find vcpkg toolchain)*

------
https://chatgpt.com/codex/tasks/task_e_6858438117388332bca93b4c2069c6e1