### PR TITLE
Fix context menu selection for tool actions

### DIFF
--- a/gui/src/toolmanagementtab.cpp
+++ b/gui/src/toolmanagementtab.cpp
@@ -517,6 +517,9 @@ void ToolManagementTab::onToolListDoubleClicked() {
 void ToolManagementTab::onToolListContextMenuRequested(const QPoint& pos) {
     auto item = m_toolTreeWidget->itemAt(pos);
     if (item) {
+        // Ensure the clicked item becomes the current selection so that
+        // subsequent actions operate on the correct tool id
+        m_toolTreeWidget->setCurrentItem(item);
         QString toolId = item->data(COL_NAME, Qt::UserRole).toString();
         bool isActive = (item->text(COL_STATUS) == "Active");
         


### PR DESCRIPTION
## Summary
- ensure context menu actions operate on the clicked tool

## Testing
- `cmake --preset ninja-release` *(fails: Could not find toolchain file)*

------
https://chatgpt.com/codex/tasks/task_e_6859628201688332afd46da770295985