### PR TITLE
Link recommended tool lists to tool manager

### DIFF
--- a/gui/include/setupconfigurationpanel.h
+++ b/gui/include/setupconfigurationpanel.h
@@ -23,6 +23,7 @@
 
 // Forward declarations
 class QListWidget;
+class QListWidgetItem;
 
 // Include manager headers
 #include "materialmanager.h"
@@ -142,6 +143,7 @@ signals:
   void automaticToolpathGenerationRequested();
   void materialSelectionChanged(const QString &materialName);
   void toolRecommendationsUpdated(const QStringList &toolIds);
+  void recommendedToolActivated(const QString &toolId);
   void requestThreadFaceSelection();
   void threadFaceSelected(const TopoDS_Shape &face);
   void threadFaceDeselected();
@@ -155,6 +157,7 @@ public slots:
   void onOperationToggled();
   void onMaterialChanged();
   void onToolSelectionRequested();
+  void onRecommendedToolDoubleClicked(QListWidgetItem *item);
   void onAddThreadFace();
   void addSelectedThreadFace(const TopoDS_Shape &face);
   void onRemoveThreadFace();

--- a/gui/src/mainwindow.cpp
+++ b/gui/src/mainwindow.cpp
@@ -343,6 +343,14 @@ void MainWindow::setupConnections()
                 this, &MainWindow::handleGenerateToolpaths);
         connect(m_setupConfigPanel, &IntuiCAM::GUI::SetupConfigurationPanel::operationToggled,
                 this, &MainWindow::handleOperationToggled);
+
+        connect(m_setupConfigPanel, &IntuiCAM::GUI::SetupConfigurationPanel::recommendedToolActivated,
+                this, [this](const QString& toolId) {
+                    if (m_toolManagementTab && m_tabWidget) {
+                        m_toolManagementTab->selectTool(toolId);
+                        m_tabWidget->setCurrentWidget(m_toolManagementTab);
+                    }
+                });
     }
     
     // Tool management connections

--- a/gui/src/setupconfigurationpanel.cpp
+++ b/gui/src/setupconfigurationpanel.cpp
@@ -710,6 +710,14 @@ void SetupConfigurationPanel::setupConnections() {
     connect(m_partingEnabledCheck, &QCheckBox::toggled, this,
             &SetupConfigurationPanel::onOperationToggled);
   }
+
+  // Connect recommended tool list interactions
+  for (auto list : m_operationToolLists) {
+    if (list) {
+      connect(list, &QListWidget::itemDoubleClicked, this,
+              &SetupConfigurationPanel::onRecommendedToolDoubleClicked);
+    }
+  }
 }
 
 void SetupConfigurationPanel::applyTabStyling() {
@@ -1157,6 +1165,16 @@ void SetupConfigurationPanel::onToolSelectionRequested() {
   if (!selectedTools.isEmpty()) {
     qDebug() << "Selected tools:" << selectedTools;
     // Here we could emit a signal to show detailed tool information
+  }
+}
+
+void SetupConfigurationPanel::onRecommendedToolDoubleClicked(QListWidgetItem *item) {
+  if (!item)
+    return;
+  QVariant data = item->data(Qt::UserRole);
+  if (data.isValid()) {
+    QString toolId = data.toString();
+    emit recommendedToolActivated(toolId);
   }
 }
 


### PR DESCRIPTION
## Summary
- forward declare `QListWidgetItem` in `SetupConfigurationPanel`
- emit a signal when a recommended tool is double-clicked
- connect recommended tool lists to the new slot
- handle the new signal in `MainWindow` by selecting the tool in the Tool Management tab

## Testing
- `cmake -S . -B build` *(fails: Qt6 missing)*

------
https://chatgpt.com/codex/tasks/task_e_685962a09910833296920211fd93674b