### PR TITLE
Fix viewer going black when switching widgets

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -136,6 +136,8 @@ The workspace management system exemplifies the application's modular architectu
   * **NEW**: Focus-independent rendering with enhanced event handling
   * **NEW**: Continuous update support via `setContinuousUpdate()`
   * **NEW**: Robust context management preventing black screen issues
+    (uses `Qt::AA_ShareOpenGLContexts` so viewer widgets keep their resources
+    even when other widgets are activated)
   * Emits `viewerInitialized()` signal for controller coordination
   * No business logic - focused solely on 3D rendering
 

--- a/docs/gui/3d_viewer.md
+++ b/docs/gui/3d_viewer.md
@@ -91,6 +91,12 @@ should be requested via `update()` when triggered from outside
 `paintGL()`. This prevents the framebuffer from being cleared and avoids the
 black screen.
 
+In addition, all `QOpenGLWidget` instances now share a single OpenGL context by
+setting the application attribute `Qt::AA_ShareOpenGLContexts` before the
+`QApplication` is created. Sharing the context ensures that the viewer widgets
+retain their resources even when other widgets gain focus or are shown, so the
+3D view does not turn black.
+
 ```cpp
 void OpenGL3DWidget::updateView()
 {

--- a/gui/src/main.cpp
+++ b/gui/src/main.cpp
@@ -1,4 +1,5 @@
 #include <QApplication>
+#include <QCoreApplication>
 #include <QDebug>
 #include <QStandardPaths>
 #include <QDir>
@@ -9,6 +10,11 @@
 
 int main(int argc, char *argv[])
 {
+    // Enable OpenGL context sharing between QOpenGLWidgets.
+    // This prevents the 3D viewers from being unloaded and turning black when
+    // another widget gains focus or is shown.
+    QCoreApplication::setAttribute(Qt::AA_ShareOpenGLContexts);
+
     QApplication app(argc, argv);
     
     // CRITICAL: Set global OpenGL surface format BEFORE creating OpenGL widgets


### PR DESCRIPTION
## Summary
- share OpenGL contexts across widgets
- document the new flag to keep viewers visible

## Testing
- `cmake --preset ninja-release` *(fails: Could not find toolchain file)*

------
https://chatgpt.com/codex/tasks/task_e_685963d31ffc833286e16e0d12210026