### PR TITLE
Fix OpenGL viewer black screen with context sharing

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -137,7 +137,8 @@ The workspace management system exemplifies the application's modular architectu
   * **NEW**: Continuous update support via `setContinuousUpdate()`
   * **NEW**: Robust context management preventing black screen issues
     (uses `Qt::AA_ShareOpenGLContexts` so viewer widgets keep their resources
-    even when other widgets are activated)
+    even when other widgets are activated and disables thread affinity checks
+    with `Qt::AA_DontCheckOpenGLContextThreadAffinity`)
   * Emits `viewerInitialized()` signal for controller coordination
   * No business logic - focused solely on 3D rendering
 

--- a/docs/gui/3d_viewer.md
+++ b/docs/gui/3d_viewer.md
@@ -95,7 +95,10 @@ In addition, all `QOpenGLWidget` instances now share a single OpenGL context by
 setting the application attribute `Qt::AA_ShareOpenGLContexts` before the
 `QApplication` is created. Sharing the context ensures that the viewer widgets
 retain their resources even when other widgets gain focus or are shown, so the
-3D view does not turn black.
+3D view does not turn black. The application also disables OpenGL context
+thread affinity checks via `Qt::AA_DontCheckOpenGLContextThreadAffinity`, which
+keeps the shared context valid even when dialogs create temporary OpenGL
+widgets.
 
 ```cpp
 void OpenGL3DWidget::updateView()

--- a/gui/src/main.cpp
+++ b/gui/src/main.cpp
@@ -14,6 +14,10 @@ int main(int argc, char *argv[])
     // This prevents the 3D viewers from being unloaded and turning black when
     // another widget gains focus or is shown.
     QCoreApplication::setAttribute(Qt::AA_ShareOpenGLContexts);
+    // Relax thread affinity checks to keep the shared context valid even when
+    // dialogs or secondary windows create their own OpenGL widgets.
+    // This further reduces the chance of the viewers going black.
+    QCoreApplication::setAttribute(Qt::AA_DontCheckOpenGLContextThreadAffinity);
 
     QApplication app(argc, argv);
     


### PR DESCRIPTION
## Summary
- ensure OpenGL context remains valid by disabling thread affinity checks
- document updated stability approach

## Testing
- `cmake ..` *(fails: Could not find Qt6Config.cmake)*

------
https://chatgpt.com/codex/tasks/task_e_6859656e7b308332ae92a9be5112dafd