### PR TITLE
Fix tool library persistence issues

### DIFF
--- a/gui/src/toolmanagementdialog.cpp
+++ b/gui/src/toolmanagementdialog.cpp
@@ -2557,7 +2557,7 @@ bool ToolManagementDialog::saveToolAssemblyToDatabase() {
     
     // Save database
     QJsonDocument doc(database);
-    if (!file.open(QIODevice::WriteOnly)) {
+    if (!file.open(QIODevice::WriteOnly | QIODevice::Truncate)) {
         qWarning() << "Failed to open tool assembly database for writing:" << dbPath;
         return false;
     }


### PR DESCRIPTION
## Summary
- ensure database files are truncated when saving tool assemblies
- persist tool deletions by updating `tool_assemblies.json`

## Testing
- `cmake --preset ninja-release` *(fails: Could not find toolchain file)*
- `cmake --build --preset ninja-release` *(fails: build directory missing)*
- `ctest --output-on-failure`

------
https://chatgpt.com/codex/tasks/task_e_685965e7bd708332a35257ef6938a74b