### PR TITLE
Fix viewer persistence in Setup tab

### DIFF
--- a/docs/gui/3d_viewer.md
+++ b/docs/gui/3d_viewer.md
@@ -100,6 +100,11 @@ thread affinity checks via `Qt::AA_DontCheckOpenGLContextThreadAffinity` so
 temporary dialogs creating OpenGL widgets do not invalidate the shared
 context.
 
+To further guard against the viewer being unloaded when other widgets gain
+focus, the main window now enables **continuous updates** whenever the
+Setup tab is active. This keeps the framebuffer alive and eliminates the
+occasional black screen when interacting with dialogs or side panels.
+
 ```cpp
 void OpenGL3DWidget::updateView()
 {

--- a/gui/src/mainwindow.cpp
+++ b/gui/src/mainwindow.cpp
@@ -667,6 +667,18 @@ void MainWindow::onTabChanged(int index)
     if (m_outputWindow) {
         m_outputWindow->append(QString("Switched to %1 tab").arg(tabName));
     }
+
+    // Keep the 3D viewer's OpenGL context active while the Setup tab is open
+    // to prevent it from unloading and turning black when other widgets gain
+    // focus. Continuous updates ensure the framebuffer stays valid.
+    if (m_3dViewer) {
+        if (index == 1) {
+            m_3dViewer->setContinuousUpdate(true);
+            m_3dViewer->update();
+        } else {
+            m_3dViewer->setContinuousUpdate(false);
+        }
+    }
 }
 
 void MainWindow::simulateToolpaths() {


### PR DESCRIPTION
## Summary
- keep 3D viewer updating while Setup tab is active
- document new continuous update approach to avoid black screens

## Testing
- `cmake -S . -B build -GNinja` *(fails: Could not find Qt6)*

------
https://chatgpt.com/codex/tasks/task_e_68596ca931508332a680f62a0a16a43b