### PR TITLE
Fix tool info sync

### DIFF
--- a/TODO
+++ b/TODO
@@ -10,7 +10,7 @@ TODO (Bugs)
 - switch the current chuck, loaded as a step file to a proper occt chuck implementation, allowing the jaws to adapt to the current raw material diameter
 
 
--* Tool Name in tool library not linked to name parameter in tool editor dialog
+ -* ~~Tool Name in tool library not linked to name parameter in tool editor dialog~~
 -* Tool Manager should be moved up one tab view to where its next to the machine tab not inside of the machine tab. 
 - Tool 3d preview in dialog should replace the view controls with a view cube and the standard mouse controls
 - if a tool is generated without a name, it cannot be deleted. Ensure a tool is only saved once a name is entered

--- a/core/toolpath/include/IntuiCAM/Toolpath/ToolTypes.h
+++ b/core/toolpath/include/IntuiCAM/Toolpath/ToolTypes.h
@@ -361,6 +361,10 @@ struct ToolAssembly {
     std::string id;                  // Unique tool assembly ID
     std::string name;                // User-defined name
     std::string manufacturer;        // Tool manufacturer/vendor
+    std::string vendor;              // Supplier or brand
+    std::string partNumber;          // Manufacturer part number
+    std::string productId;           // Catalog or internal product ID
+    std::string productLink;         // Link to online catalog page
     ToolType toolType;
     
     // Component references (only one set will be used based on type)
@@ -395,9 +399,12 @@ struct ToolAssembly {
     std::string notes;
     std::map<std::string, std::string> customProperties; // Extensible properties
     
-    ToolAssembly() : toolType(ToolType::GENERAL_TURNING), toolOffset_X(0), toolOffset_Z(0),
-                    toolLengthOffset(0), toolRadiusOffset(0), turretPosition(1), isActive(true),
-                    expectedLifeMinutes(480), usageMinutes(0), cycleCount(0) {}
+    ToolAssembly()
+        : toolType(ToolType::GENERAL_TURNING),
+          toolOffset_X(0), toolOffset_Z(0),
+          toolLengthOffset(0), toolRadiusOffset(0),
+          turretPosition(1), isActive(true),
+          expectedLifeMinutes(480), usageMinutes(0), cycleCount(0) {}
 };
 
 // ============================================================================

--- a/gui/include/toolmanagementdialog.h
+++ b/gui/include/toolmanagementdialog.h
@@ -100,6 +100,7 @@ public:
 signals:
     void toolSaved(const QString& toolId);
     void errorOccurred(const QString& message);
+    void toolNameChanged(const QString& toolId, const QString& newName);
     
     // 3D visualization signals
     void tool3DVisualizationChanged(const QString& toolId);
@@ -114,6 +115,7 @@ private slots:
     void onHolderParameterChanged();
     void onCuttingDataChanged();
     void onToolInfoChanged();
+    void onToolNameEdited(const QString& text);
     void onISOCodeChanged();
     
     // 3D visualization slots

--- a/gui/src/toolmanagementdialog.cpp
+++ b/gui/src/toolmanagementdialog.cpp
@@ -546,6 +546,7 @@ void ToolManagementDialog::connectParameterSignals() {
     // Tool Info Parameters
     if (m_toolNameEdit) {
         connect(m_toolNameEdit, &QLineEdit::textChanged, this, &ToolManagementDialog::onToolInfoChanged);
+        connect(m_toolNameEdit, &QLineEdit::textChanged, this, &ToolManagementDialog::onToolNameEdited);
     }
     if (m_vendorEdit) {
         connect(m_vendorEdit, &QLineEdit::textChanged, this, &ToolManagementDialog::onToolInfoChanged);
@@ -763,6 +764,21 @@ void ToolManagementDialog::loadToolParametersIntoFields(const ToolAssembly& asse
     // Load tool information
     if (m_toolNameEdit) {
         m_toolNameEdit->setText(QString::fromStdString(assembly.name));
+    }
+    if (m_vendorEdit) {
+        m_vendorEdit->setText(QString::fromStdString(assembly.vendor));
+    }
+    if (m_manufacturerEdit) {
+        m_manufacturerEdit->setText(QString::fromStdString(assembly.manufacturer));
+    }
+    if (m_partNumberEdit) {
+        m_partNumberEdit->setText(QString::fromStdString(assembly.partNumber));
+    }
+    if (m_productIdEdit) {
+        m_productIdEdit->setText(QString::fromStdString(assembly.productId));
+    }
+    if (m_productLinkEdit) {
+        m_productLinkEdit->setText(QString::fromStdString(assembly.productLink));
     }
     if (m_toolNumberEdit) {
         m_toolNumberEdit->setText(QString::fromStdString(assembly.toolNumber));
@@ -1351,6 +1367,11 @@ void ToolManagementDialog::onToolInfoChanged() {
     markAsModified();
 }
 
+void ToolManagementDialog::onToolNameEdited(const QString& text) {
+    m_currentToolAssembly.name = text.toStdString();
+    emit toolNameChanged(m_currentToolId, text);
+}
+
 void ToolManagementDialog::onISOCodeChanged() {
     markAsModified();
     // TODO: Validate ISO code format
@@ -1694,6 +1715,21 @@ void ToolManagementDialog::initializeToolAssemblyForType(ToolType toolType) {
 void ToolManagementDialog::updateToolInfoFromFields() {
     if (m_toolNameEdit) {
         m_currentToolAssembly.name = m_toolNameEdit->text().toStdString();
+    }
+    if (m_vendorEdit) {
+        m_currentToolAssembly.vendor = m_vendorEdit->text().toStdString();
+    }
+    if (m_manufacturerEdit) {
+        m_currentToolAssembly.manufacturer = m_manufacturerEdit->text().toStdString();
+    }
+    if (m_partNumberEdit) {
+        m_currentToolAssembly.partNumber = m_partNumberEdit->text().toStdString();
+    }
+    if (m_productIdEdit) {
+        m_currentToolAssembly.productId = m_productIdEdit->text().toStdString();
+    }
+    if (m_productLinkEdit) {
+        m_currentToolAssembly.productLink = m_productLinkEdit->text().toStdString();
     }
     if (m_toolNumberEdit) {
         m_currentToolAssembly.toolNumber = m_toolNumberEdit->text().toStdString();
@@ -2774,6 +2810,10 @@ QJsonObject ToolManagementDialog::toolAssemblyToJson(const ToolAssembly& assembl
     json["id"] = QString::fromStdString(assembly.id);
     json["name"] = QString::fromStdString(assembly.name);
     json["manufacturer"] = QString::fromStdString(assembly.manufacturer);
+    json["vendor"] = QString::fromStdString(assembly.vendor);
+    json["partNumber"] = QString::fromStdString(assembly.partNumber);
+    json["productId"] = QString::fromStdString(assembly.productId);
+    json["productLink"] = QString::fromStdString(assembly.productLink);
     json["toolType"] = static_cast<int>(assembly.toolType);
     
     // Tool positioning
@@ -2826,6 +2866,10 @@ ToolAssembly ToolManagementDialog::toolAssemblyFromJson(const QJsonObject& json)
     assembly.id = json["id"].toString().toStdString();
     assembly.name = json["name"].toString().toStdString();
     assembly.manufacturer = json["manufacturer"].toString().toStdString();
+    assembly.vendor = json["vendor"].toString().toStdString();
+    assembly.partNumber = json["partNumber"].toString().toStdString();
+    assembly.productId = json["productId"].toString().toStdString();
+    assembly.productLink = json["productLink"].toString().toStdString();
     assembly.toolType = static_cast<ToolType>(json["toolType"].toInt());
     
     // Tool positioning

--- a/gui/src/toolmanagementtab.cpp
+++ b/gui/src/toolmanagementtab.cpp
@@ -649,6 +649,16 @@ void ToolManagementTab::addNewTool() {
                         QString("Tool '%1' was not properly saved to the database. Please try again.").arg(toolId));
                 }
             });
+    connect(dialog, &ToolManagementDialog::toolNameChanged,
+            this, [this](const QString& id, const QString& name) {
+                for (int i = 0; i < m_toolTreeWidget->topLevelItemCount(); ++i) {
+                    auto item = m_toolTreeWidget->topLevelItem(i);
+                    if (item->data(COL_NAME, Qt::UserRole).toString() == id) {
+                        item->setText(COL_NAME, name);
+                        break;
+                    }
+                }
+            });
     
     // Connect error handling
     connect(dialog, &ToolManagementDialog::errorOccurred,
@@ -798,6 +808,16 @@ void ToolManagementTab::editSelectedTool() {
                 refreshToolList();
                 selectTool(modifiedToolId); // Re-select the modified tool
                 emit toolModified(modifiedToolId);
+            });
+    connect(dialog, &ToolManagementDialog::toolNameChanged,
+            this, [this](const QString& id, const QString& name) {
+                for (int i = 0; i < m_toolTreeWidget->topLevelItemCount(); ++i) {
+                    auto item = m_toolTreeWidget->topLevelItem(i);
+                    if (item->data(COL_NAME, Qt::UserRole).toString() == id) {
+                        item->setText(COL_NAME, name);
+                        break;
+                    }
+                }
             });
     
     // Connect error handling
@@ -2109,6 +2129,16 @@ void ToolManagementTab::onToolPropertiesAction() {
         connect(dialog, &ToolManagementDialog::toolSaved,
                 this, [this](const QString&) {
                     refreshToolList();
+                });
+        connect(dialog, &ToolManagementDialog::toolNameChanged,
+                this, [this](const QString& id, const QString& name) {
+                    for (int i = 0; i < m_toolTreeWidget->topLevelItemCount(); ++i) {
+                        auto item = m_toolTreeWidget->topLevelItem(i);
+                        if (item->data(COL_NAME, Qt::UserRole).toString() == id) {
+                            item->setText(COL_NAME, name);
+                            break;
+                        }
+                    }
                 });
         
         dialog->exec();


### PR DESCRIPTION
## Summary
- store vendor and product fields in ToolAssembly
- load and save the extra fields in ToolManagementDialog
- sync tool name edits with the tool list
- mark TODO item resolved

## Testing
- `ctest --output-on-failure`

------
https://chatgpt.com/codex/tasks/task_e_68597abb2d088332a59283bf28af4f8f