### PR TITLE
Add dynamic material cutting data menus

### DIFF
--- a/core/toolpath/include/IntuiCAM/Toolpath/ToolTypes.h
+++ b/core/toolpath/include/IntuiCAM/Toolpath/ToolTypes.h
@@ -339,8 +339,15 @@ struct CuttingData {
                    feedPerRevolution(true), cuttingFeedrate(0.2), leadInFeedrate(0.1),
                    leadOutFeedrate(0.1), maxDepthOfCut(2.0), maxFeedrate(1000),
                    minSurfaceSpeed(50), maxSurfaceSpeed(500), floodCoolant(false),
-                   mistCoolant(false), preferredCoolant(CoolantType::NONE), 
+                   mistCoolant(false), preferredCoolant(CoolantType::NONE),
                    coolantPressure(0), coolantFlow(0) {}
+};
+
+// Cutting data specific to a workpiece material
+struct MaterialCuttingData {
+    bool enabled;
+    CuttingData data;
+    MaterialCuttingData() : enabled(true) {}
 };
 
 // ============================================================================
@@ -407,6 +414,7 @@ struct ToolAssembly {
     // User properties
     std::string notes;
     std::map<std::string, std::string> customProperties; // Extensible properties
+    std::map<std::string, MaterialCuttingData> materialCuttingData; // Per-material data
     
     ToolAssembly()
         : toolType(ToolType::GENERAL_TURNING),

--- a/gui/include/mainwindow.h
+++ b/gui/include/mainwindow.h
@@ -77,6 +77,8 @@ public:
     MainWindow(QWidget *parent = nullptr);
     ~MainWindow();
 
+    IntuiCAM::GUI::MaterialManager* materialManager() const { return m_materialManager; }
+
 private slots:
     void newProject();
     void openProject();

--- a/gui/include/toolmanagementdialog.h
+++ b/gui/include/toolmanagementdialog.h
@@ -18,6 +18,7 @@
 #include <QFormLayout>
 #include <QTimer>
 #include <QSlider>
+#include <QToolBox>
 #include <QJsonObject>
 
 // OpenCASCADE includes
@@ -66,6 +67,7 @@ namespace Toolpath {
 namespace IntuiCAM {
     namespace GUI {
         class ToolManager;
+        class MaterialManager;
     }
 }
 
@@ -77,10 +79,13 @@ class ToolManagementDialog : public QDialog
 
 public:
     // Constructor for editing an existing tool
-    explicit ToolManagementDialog(const QString& toolId, QWidget *parent = nullptr);
+    explicit ToolManagementDialog(const QString& toolId,
+                                  MaterialManager* materialManager,
+                                  QWidget *parent = nullptr);
     
     // Constructor for creating a new tool
-    explicit ToolManagementDialog(IntuiCAM::Toolpath::ToolType toolType = IntuiCAM::Toolpath::ToolType::GENERAL_TURNING, 
+    explicit ToolManagementDialog(IntuiCAM::Toolpath::ToolType toolType = IntuiCAM::Toolpath::ToolType::GENERAL_TURNING,
+                                  MaterialManager* materialManager = nullptr,
                                   QWidget *parent = nullptr);
     
     ~ToolManagementDialog();
@@ -121,6 +126,7 @@ private slots:
     // UI logic change slots
     void onConstantSurfaceSpeedToggled(bool enabled);
     void onFeedPerRevolutionToggled(bool enabled);
+    void onMaterialAdded(const QString& materialName);
     
     // 3D visualization slots
     void onVisualizationModeChanged(int mode);
@@ -164,6 +170,10 @@ private:
     void createHolderPanel();
     void createCuttingDataPanel();
     void createToolInfoPanel();
+    void createMaterialCuttingSections();
+    void addMaterialCuttingSection(const QString& materialName);
+    void loadMaterialCuttingData(const IntuiCAM::Toolpath::ToolAssembly& assembly);
+    void updateMaterialCuttingDataFromFields();
     
     // 3D Visualization methods
     void setup3DViewer();
@@ -445,6 +455,17 @@ private:
     
     // Tool manager reference for broader integration
     IntuiCAM::GUI::ToolManager* m_toolManager;
+    IntuiCAM::GUI::MaterialManager* m_materialManager;
+
+    struct MaterialWidgetSet {
+        QCheckBox* enable;
+        QDoubleSpinBox* speed;
+        QDoubleSpinBox* feed;
+        QDoubleSpinBox* depth;
+    };
+
+    QToolBox* m_materialToolBox;
+    QMap<QString, MaterialWidgetSet> m_materialWidgets;
     
     // Tool geometry objects
     Handle(AIS_Shape) m_currentInsertShape;

--- a/gui/src/mainwindow.cpp
+++ b/gui/src/mainwindow.cpp
@@ -359,7 +359,7 @@ void MainWindow::setupConnections()
         connect(m_toolManagementTab, &ToolManagementTab::toolDoubleClicked,
                 this, [this](const QString& toolId) {
                     // Create a new dialog for editing this specific tool
-                    auto dialog = new ToolManagementDialog(toolId, this);
+                    auto dialog = new ToolManagementDialog(toolId, m_materialManager, this);
                     
                     // Connect to handle tool saves
                     connect(dialog, &ToolManagementDialog::toolSaved,

--- a/gui/src/toolmanagementdialog.cpp
+++ b/gui/src/toolmanagementdialog.cpp
@@ -1,4 +1,5 @@
 #include "toolmanagementdialog.h"
+#include "materialmanager.h"
 
 #include <QApplication>
 #include <QDateTime>
@@ -41,7 +42,9 @@
 using namespace IntuiCAM::Toolpath;
 
 // Constructor for editing an existing tool
-ToolManagementDialog::ToolManagementDialog(const QString& toolId, QWidget *parent)
+ToolManagementDialog::ToolManagementDialog(const QString& toolId,
+                                           MaterialManager* materialManager,
+                                           QWidget *parent)
     : QDialog(parent)
     , m_mainLayout(nullptr)
     , m_contentLayout(nullptr)
@@ -62,6 +65,9 @@ ToolManagementDialog::ToolManagementDialog(const QString& toolId, QWidget *paren
     , m_autoSaveTimer(new QTimer(this))
     , m_autoSaveEnabled(true)
     , m_toolManager(nullptr)
+    , m_materialManager(materialManager)
+    , m_materialToolBox(nullptr)
+    , m_materialToolBox(nullptr)
 {
     // Load tool data first to get the correct tool type
     if (loadToolAssemblyFromDatabase(toolId)) {
@@ -84,7 +90,9 @@ ToolManagementDialog::ToolManagementDialog(const QString& toolId, QWidget *paren
 }
 
 // Constructor for creating a new tool
-ToolManagementDialog::ToolManagementDialog(ToolType toolType, QWidget *parent)
+ToolManagementDialog::ToolManagementDialog(ToolType toolType,
+                                           MaterialManager* materialManager,
+                                           QWidget *parent)
     : QDialog(parent)
     , m_mainLayout(nullptr)
     , m_contentLayout(nullptr)
@@ -105,6 +113,7 @@ ToolManagementDialog::ToolManagementDialog(ToolType toolType, QWidget *parent)
     , m_autoSaveTimer(new QTimer(this))
     , m_autoSaveEnabled(true)
     , m_toolManager(nullptr)
+    , m_materialManager(materialManager)
 {
     setupUI();
     setupAutoSave();
@@ -762,6 +771,7 @@ void ToolManagementDialog::updateToolAssemblyFromFields() {
     // Always update holder and cutting data
     updateHolderDataFromFields();
     updateCuttingDataFromFields();
+    updateMaterialCuttingDataFromFields();
     updateToolInfoFromFields();
 }
 
@@ -846,6 +856,7 @@ void ToolManagementDialog::loadToolParametersIntoFields(const ToolAssembly& asse
     
     // Load cutting data
     loadCuttingDataParameters(assembly.cuttingData);
+    loadMaterialCuttingData(assembly);
     
     // Load holder parameters
     if (assembly.holder) {
@@ -1124,7 +1135,16 @@ QWidget* ToolManagementDialog::createCuttingDataTab() {
     coolantLayout->addRow("Coolant Flow:", m_coolantFlowSpin);
     
     m_cuttingDataLayout->addRow(coolantGroup);
-    
+
+    // Material specific parameters
+    m_materialToolBox = new QToolBox();
+    m_cuttingDataLayout->addRow(m_materialToolBox);
+    createMaterialCuttingSections();
+    if (m_materialManager) {
+        connect(m_materialManager, &MaterialManager::materialAdded,
+                this, &ToolManagementDialog::onMaterialAdded);
+    }
+
     return widget;
 }
 
@@ -2155,6 +2175,26 @@ void ToolManagementDialog::loadCuttingDataParameters(const CuttingData& cuttingD
     onFeedPerRevolutionToggled(cuttingData.feedPerRevolution);
 }
 
+void ToolManagementDialog::loadMaterialCuttingData(const ToolAssembly& assembly) {
+    if (!m_materialManager) {
+        return;
+    }
+    QStringList materials = m_materialManager->getAllMaterialNames();
+    for (const QString& mat : materials) {
+        if (!m_materialWidgets.contains(mat)) continue;
+        const auto& widgets = m_materialWidgets[mat];
+        auto it = assembly.materialCuttingData.find(mat.toStdString());
+        if (it != assembly.materialCuttingData.end()) {
+            widgets.enable->setChecked(it->second.enabled);
+            widgets.speed->setValue(it->second.data.surfaceSpeed);
+            widgets.feed->setValue(it->second.data.cuttingFeedrate);
+            widgets.depth->setValue(it->second.data.maxDepthOfCut);
+        } else {
+            widgets.enable->setChecked(false);
+        }
+    }
+}
+
 // Parameter updating methods - sync UI changes back to data
 void ToolManagementDialog::updateGeneralTurningInsertFromFields() {
     if (!m_currentToolAssembly.turningInsert) {
@@ -2403,6 +2443,63 @@ void ToolManagementDialog::updateCuttingDataFromFields() {
     if (m_coolantFlowSpin) {
         m_currentToolAssembly.cuttingData.coolantFlow = m_coolantFlowSpin->value();
     }
+}
+
+void ToolManagementDialog::updateMaterialCuttingDataFromFields() {
+    if (!m_materialManager) {
+        return;
+    }
+    QStringList materials = m_materialManager->getAllMaterialNames();
+    for (const QString& mat : materials) {
+        if (!m_materialWidgets.contains(mat)) continue;
+        const auto& widgets = m_materialWidgets[mat];
+        MaterialCuttingData mdata;
+        mdata.enabled = widgets.enable->isChecked();
+        mdata.data.surfaceSpeed = widgets.speed->value();
+        mdata.data.cuttingFeedrate = widgets.feed->value();
+        mdata.data.maxDepthOfCut = widgets.depth->value();
+        m_currentToolAssembly.materialCuttingData[mat.toStdString()] = mdata;
+    }
+}
+
+void ToolManagementDialog::createMaterialCuttingSections() {
+    if (!m_materialManager) {
+        return;
+    }
+    QStringList materials = m_materialManager->getAllMaterialNames();
+    for (const QString& mat : materials) {
+        addMaterialCuttingSection(mat);
+    }
+}
+
+void ToolManagementDialog::addMaterialCuttingSection(const QString& materialName) {
+    if (m_materialWidgets.contains(materialName)) {
+        return;
+    }
+    QWidget* page = new QWidget();
+    QFormLayout* layout = new QFormLayout(page);
+    MaterialWidgetSet widgets;
+    widgets.enable = new QCheckBox("Enable");
+    widgets.speed = new QDoubleSpinBox();
+    widgets.speed->setRange(0.0, 10000.0);
+    widgets.speed->setSuffix(" m/min");
+    widgets.feed = new QDoubleSpinBox();
+    widgets.feed->setRange(0.0, 10.0);
+    widgets.feed->setDecimals(3);
+    widgets.feed->setSuffix(" mm/rev");
+    widgets.depth = new QDoubleSpinBox();
+    widgets.depth->setRange(0.0, 10.0);
+    widgets.depth->setSuffix(" mm");
+    layout->addRow(widgets.enable);
+    layout->addRow("Surface Speed:", widgets.speed);
+    layout->addRow("Feed Rate:", widgets.feed);
+    layout->addRow("Depth of Cut:", widgets.depth);
+    m_materialToolBox->addItem(page, materialName);
+    m_materialWidgets.insert(materialName, widgets);
+}
+
+void ToolManagementDialog::onMaterialAdded(const QString& materialName) {
+    addMaterialCuttingSection(materialName);
 }
 
 void ToolManagementDialog::createGeneralTurningPanel() {
@@ -3003,6 +3100,14 @@ QJsonObject ToolManagementDialog::toolAssemblyToJson(const ToolAssembly& assembl
     
     // Cutting data
     json["cuttingData"] = cuttingDataToJson(assembly.cuttingData);
+
+    QJsonObject matObj;
+    for (const auto& pair : assembly.materialCuttingData) {
+        QJsonObject dataJson = cuttingDataToJson(pair.second.data);
+        dataJson["enabled"] = pair.second.enabled;
+        matObj[QString::fromStdString(pair.first)] = dataJson;
+    }
+    json["materialCuttingData"] = matObj;
     
     // Inserts based on tool type
     if (assembly.turningInsert) {
@@ -3069,6 +3174,16 @@ ToolAssembly ToolManagementDialog::toolAssemblyFromJson(const QJsonObject& json)
     // Cutting data
     if (json.contains("cuttingData")) {
         assembly.cuttingData = cuttingDataFromJson(json["cuttingData"].toObject());
+    }
+    if (json.contains("materialCuttingData")) {
+        QJsonObject matObj = json["materialCuttingData"].toObject();
+        for (auto it = matObj.constBegin(); it != matObj.constEnd(); ++it) {
+            QJsonObject dataObj = it.value().toObject();
+            MaterialCuttingData mdata;
+            mdata.enabled = dataObj["enabled"].toBool(true);
+            mdata.data = cuttingDataFromJson(dataObj);
+            assembly.materialCuttingData[it.key().toStdString()] = mdata;
+        }
     }
     
     // Inserts based on what's available

--- a/gui/src/toolmanagementtab.cpp
+++ b/gui/src/toolmanagementtab.cpp
@@ -1,6 +1,8 @@
 ﻿#include "toolmanagementtab.h"
 #include "toolmanagementdialog.h"
 #include "IntuiCAM/Toolpath/ToolTypes.h"
+#include "mainwindow.h"
+#include "materialmanager.h"
 
 #include <QHeaderView>
 #include <QMessageBox>
@@ -622,7 +624,11 @@ void ToolManagementTab::addNewTool() {
     // Clean up any existing tools with empty IDs before adding new tool
     cleanupEmptyIdTools();
     
-    auto dialog = new ToolManagementDialog(IntuiCAM::Toolpath::ToolType::GENERAL_TURNING, this);
+    MaterialManager* mm = nullptr;
+    if (auto mw = qobject_cast<MainWindow*>(parent())) {
+        mm = mw->materialManager();
+    }
+    auto dialog = new ToolManagementDialog(IntuiCAM::Toolpath::ToolType::GENERAL_TURNING, mm, this);
     
     // Connect signals to handle new tool creation
     connect(dialog, &ToolManagementDialog::toolSaved,
@@ -799,7 +805,11 @@ void ToolManagementTab::editSelectedTool() {
         }
     }
     
-    auto dialog = new ToolManagementDialog(toolId, this);
+    MaterialManager* mm = nullptr;
+    if (auto mw = qobject_cast<MainWindow*>(parent())) {
+        mm = mw->materialManager();
+    }
+    auto dialog = new ToolManagementDialog(toolId, mm, this);
     
     // Connect signals
     connect(dialog, &ToolManagementDialog::toolSaved,
@@ -2123,7 +2133,11 @@ void ToolManagementTab::onToolPropertiesAction() {
     // Open a properties dialog for the selected tool
     QString toolId = getSelectedToolId();
     if (!toolId.isEmpty()) {
-        auto dialog = new ToolManagementDialog(toolId, this);
+        MaterialManager* mm = nullptr;
+        if (auto mw = qobject_cast<MainWindow*>(parent())) {
+            mm = mw->materialManager();
+        }
+        auto dialog = new ToolManagementDialog(toolId, mm, this);
         
         // Connect save signal to refresh list
         connect(dialog, &ToolManagementDialog::toolSaved,


### PR DESCRIPTION
## Summary
- store per-material cutting data in `ToolAssembly`
- expose material manager in MainWindow
- create material-specific cutting data sections in tool dialog
- update dialog constructors and call sites to use material manager

## Testing
- `cmake .. -DCMAKE_BUILD_TYPE=Debug` *(fails: Qt6Config.cmake not found)*

------
https://chatgpt.com/codex/tasks/task_e_6859a4f6dddc83328c5b20918d8e53a5