### PR TITLE
Fix distance slider updates

### DIFF
--- a/gui/src/mainwindow.cpp
+++ b/gui/src/mainwindow.cpp
@@ -2094,9 +2094,22 @@ void MainWindow::handleManualAxisSelected(double diameter, const gp_Ax1& axis)
 
 void MainWindow::handlePartLoadingDistanceChanged(double distance)
 {
+    if (!m_workspaceController || !m_workspaceController->isInitialized()) {
+        return;
+    }
+
     statusBar()->showMessage(QString("Distance to chuck changed: %1mm").arg(distance, 0, 'f', 1), 2000);
+
     if (m_outputWindow) {
         m_outputWindow->append(QString("Part distance to chuck updated: %1mm").arg(distance, 0, 'f', 1));
+    }
+
+    bool success = m_workspaceController->updateDistanceToChuck(distance);
+    if (!success) {
+        statusBar()->showMessage(tr("Failed to update distance to chuck"), 3000);
+        if (m_outputWindow) {
+            m_outputWindow->append("Failed to update distance to chuck");
+        }
     }
 }
 


### PR DESCRIPTION
## Summary
- update `handlePartLoadingDistanceChanged` so moving the slider updates the workspace

## Testing
- `cmake -S . -B build -G Ninja` *(fails: Could not find Qt6)*
- `cmake --build build` *(fails: build.ninja not found)*
- `ctest --test-dir build`

------
https://chatgpt.com/codex/tasks/task_e_685d356682fc83328a3107ec725b11fa