### PR TITLE
Fix Internal Features tile default state

### DIFF
--- a/gui/src/operationtilewidget.cpp
+++ b/gui/src/operationtilewidget.cpp
@@ -448,7 +448,16 @@ void OperationTileContainer::setupUI()
         "Parting"
     };
     
-    QStringList defaultEnabled = {"Facing", "Roughing", "Finishing", "Parting"};
+    // Enable operations that should be active by default.  The internal
+    // features tile needs to reflect the default configuration where
+    // machining internal geometry is turned on, so include it here.
+    QStringList defaultEnabled = {
+        "Facing",
+        "Internal Features",
+        "Roughing",
+        "Finishing",
+        "Parting"
+    };
     
     for (const QString& operation : operations) {
         bool enabled = defaultEnabled.contains(operation);


### PR DESCRIPTION
## Summary
- enable the Internal Features tile by default

## Testing
- `cmake -S . -B build` *(fails: Qt6 missing)*

------
https://chatgpt.com/codex/tasks/task_e_685d360620508332ad09471f21ce8aa8