### PR TITLE
Fix profile not updating on position change

### DIFF
--- a/gui/src/workspacecontroller.cpp
+++ b/gui/src/workspacecontroller.cpp
@@ -457,7 +457,10 @@ bool WorkspaceController::updateDistanceToChuck(double distance)
                 recalculateRawMaterial(-1.0); // Use current diameter
                 qDebug() << "WorkspaceController: Recalculated raw material for new position";
             }
-            
+
+            // Update profile display to keep it aligned with the workpiece
+            updateProfileDisplay();
+
             // Make sure toolpaths are properly transformed
             qDebug() << "WorkspaceController: Emitting workpiecePositionChanged signal for toolpath updates";
             emit workpiecePositionChanged(distance);


### PR DESCRIPTION
## Summary
- update the workspace controller to refresh the extracted profile whenever the workpiece position changes

## Testing
- `cmake --preset ninja-release` *(fails: Could not find toolchain file)*

------
https://chatgpt.com/codex/tasks/task_e_685d82f668a4833290dd0cc843f8c200