### PR TITLE
Fix facing allowance use in raw material calculation

### DIFF
--- a/gui/src/workspacecontroller.cpp
+++ b/gui/src/workspacecontroller.cpp
@@ -1139,7 +1139,10 @@ void WorkspaceController::initializeWorkCoordinateSystem(const gp_Ax1& axis) {
             
             // Calculate raw material end position
             // Raw material extends beyond the workpiece with facing allowance
-            double facingAllowance = 10.0; // From raw material manager default
+            double facingAllowance = 10.0;
+            if (m_rawMaterialManager) {
+                facingAllowance = m_rawMaterialManager->getFacingAllowance();
+            }
             double rawMaterialEnd = maxProjection + facingAllowance;
             
             // Ensure minimum extension past chuck face (Z=0)


### PR DESCRIPTION
## Summary
- initialize the work coordinate system using the facing allowance configured in the GUI

## Testing
- `cmake --preset ninja-release` *(fails: could not find toolchain file)*
- `ctest --preset ninja-release` *(fails: No tests were found)*

------
https://chatgpt.com/codex/tasks/task_e_685d8b6b878c8332b82b2eb682844012