### PR TITLE
Improve raw material update responsiveness

### DIFF
--- a/gui/include/workspacecontroller.h
+++ b/gui/include/workspacecontroller.h
@@ -2,6 +2,7 @@
 #define WORKSPACECONTROLLER_H
 
 #include <QObject>
+#include <QTimer>
 #include <QString>
 #include <QVector>
 
@@ -350,6 +351,9 @@ private:
     IntuiCAM::Toolpath::LatheProfile::Profile2D m_extractedProfile;
     Handle(AIS_InteractiveObject) m_profileDisplayObject;
     bool m_profileVisible;
+
+    // Timer for debouncing raw material/profile updates when position changes
+    QTimer* m_materialUpdateTimer { nullptr };
     
     /**
      * @brief Set up signal connections between managers


### PR DESCRIPTION
## Summary
- add timer for raw material/profile updates
- debounce updates when adjusting distance to chuck

## Testing
- `cmake -B build -S . -DINTUICAM_BUILD_TESTS=ON` *(fails: FindQt6.cmake not found)*

------
https://chatgpt.com/codex/tasks/task_e_685d8b307df483328f5a2adf1eaac773