### PR TITLE
Debounce raw material update with timer

### DIFF
--- a/gui/src/workspacecontroller.cpp
+++ b/gui/src/workspacecontroller.cpp
@@ -464,7 +464,8 @@ bool WorkspaceController::updateDistanceToChuck(double distance)
             qDebug() << "WorkspaceController: Workpiece positioned at" << distance << "mm from chuck";
             
             // Debounce raw material/profile updates to avoid slider lag
-            m_materialUpdateTimer->start(250); // restart timer
+            // Use a short delay so interactive sliders remain responsive
+            m_materialUpdateTimer->start(100); // restart timer with small delay
 
             // Make sure toolpaths are properly transformed
             qDebug() << "WorkspaceController: Emitting workpiecePositionChanged signal for toolpath updates";


### PR DESCRIPTION
## Summary
- avoid lag while dragging the distance-to-chuck slider
- start the raw material recalculation timer with a short delay

## Testing
- `cmake -S . -B build` *(fails: Could NOT find MPI)*

------
https://chatgpt.com/codex/tasks/task_e_685d9b73d2748332a8044aa6143f307c