### PR TITLE
Highlight operation tiles with colored border

### DIFF
--- a/gui/include/operationtilewidget.h
+++ b/gui/include/operationtilewidget.h
@@ -122,6 +122,7 @@ private:
     QColor m_hoverColor;
     QColor m_textColor;
     QColor m_borderColor;
+    QColor m_selectionBorderColor;
     
     // Context menu
     QMenu* m_contextMenu;

--- a/gui/src/operationtilewidget.cpp
+++ b/gui/src/operationtilewidget.cpp
@@ -93,6 +93,7 @@ OperationTileWidget::OperationTileWidget(const QString& operationName, bool enab
     m_hoverColor = m_enabledColor.lighter(110);
     m_textColor = QColor("#212121");  // Dark grey
     m_borderColor = QColor("#BDBDBD");  // Medium grey
+    m_selectionBorderColor = QColor("#FFD700");  // Gold for selected highlight
     
     setupUI();
     updateColors();
@@ -403,7 +404,7 @@ void OperationTileWidget::paintEvent(QPaintEvent* event)
     // Use thicker border and distinct color for selected tiles
     int borderWidth = m_selected ? 3 : 2;
     if (m_selected && m_enabled) {
-        borderColor = m_enabledColor.lighter(150);
+        borderColor = m_selectionBorderColor;
     }
     
     painter.setPen(QPen(borderColor, borderWidth));
@@ -426,7 +427,7 @@ void OperationTileWidget::paintEvent(QPaintEvent* event)
         painter.drawLine(p2, p3);
         
         // Draw additional selection highlight around the border
-        QPen highlightPen(m_enabledColor.lighter(150), 1, Qt::DashLine);
+        QPen highlightPen(m_selectionBorderColor, 1, Qt::DashLine);
         painter.setPen(highlightPen);
         painter.drawRoundedRect(rect.adjusted(-1, -1, 1, 1), 9, 9);
     } else if (m_enabled) {


### PR DESCRIPTION
## Summary
- add `m_selectionBorderColor` member to store the highlight color
- initialize selection border color in `OperationTileWidget`
- paint selected tiles using the new border color

## Testing
- `cmake --version`

------
https://chatgpt.com/codex/tasks/task_e_685da61d4410833287d258e6eeb93ecc