### PR TITLE
Fix lathe toolpath orientation

### DIFF
--- a/core/toolpath/src/ToolpathDisplayObject.cpp
+++ b/core/toolpath/src/ToolpathDisplayObject.cpp
@@ -93,10 +93,10 @@ void ToolpathDisplayObject::ComputeSelection(const Handle(SelectMgr_Selection)& 
         const auto& move = moves[i];
         
         // Apply the same coordinate transformation as in the 2D profile
-        // Toolpath coordinates are stored as (radius, 0, axial) where X is radial
-        // and Z is axial.  Display directly in the viewer's XZ plane.
-        gp_Pnt startPnt(move.startPoint.x, 0.0, move.startPoint.z);  // (radius, 0, axial)
-        gp_Pnt endPnt(move.endPoint.x, 0.0, move.endPoint.z);        // (radius, 0, axial)
+        // Movements store axial position in `x` and radial position in `z`.
+        // Convert to viewer coordinates (X = radius, Z = axial).
+        gp_Pnt startPnt(move.startPoint.z, 0.0, move.startPoint.x);  // (radius, 0, axial)
+        gp_Pnt endPnt(move.endPoint.z, 0.0, move.endPoint.x);        // (radius, 0, axial)
         
         // Ensure Y=0 to constrain to XZ plane for lathe operations
         startPnt.SetY(0.0);
@@ -276,11 +276,10 @@ void ToolpathDisplayObject::computeWireframePresentation(const Handle(Prs3d_Pres
         const auto& currentMove = moves[i];
         
         // COORDINATE SYSTEM TRANSFORMATION FOR LATHE OPERATIONS
-        // Toolpath coordinates already follow the (radius, 0, axial) convention
-        // matching the 2D profile (X = radius, Z = axial). Display them directly
-        // in the viewer's XZ plane.
-        gp_Pnt startPnt(prevMove.position.x, 0.0, prevMove.position.z);      // (radius, 0, axial)
-        gp_Pnt endPnt(currentMove.position.x, 0.0, currentMove.position.z);  // (radius, 0, axial)
+        // Movements store axial position in `x` and radial position in `z`.
+        // Convert to viewer coordinates where X is radius and Z is axial.
+        gp_Pnt startPnt(prevMove.position.z, 0.0, prevMove.position.x);      // (radius, 0, axial)
+        gp_Pnt endPnt(currentMove.position.z, 0.0, currentMove.position.x);  // (radius, 0, axial)
         
         // Ensure Y=0 to constrain to XZ plane for lathe operations
         startPnt.SetY(0.0);
@@ -402,9 +401,9 @@ void ToolpathDisplayObject::computeMoveTypePresentation(const Handle(Prs3d_Prese
         }
         
         // Apply the same coordinate transformation as the 2D profile
-        // Toolpath points are defined with X as radius and Z as axial
-        gp_Pnt startPnt(move.startPoint.x, 0.0, move.startPoint.z);  // (radius, 0, axial)
-        gp_Pnt endPnt(move.endPoint.x, 0.0, move.endPoint.z);        // (radius, 0, axial)
+        // Movements store axial position in `x` and radial position in `z`.
+        gp_Pnt startPnt(move.startPoint.z, 0.0, move.startPoint.x);  // (radius, 0, axial)
+        gp_Pnt endPnt(move.endPoint.z, 0.0, move.endPoint.x);        // (radius, 0, axial)
         
         // Ensure Y=0 to constrain to XZ plane for lathe operations
         startPnt.SetY(0.0);

--- a/core/toolpath/src/ToolpathGenerationPipeline.cpp
+++ b/core/toolpath/src/ToolpathGenerationPipeline.cpp
@@ -1068,8 +1068,12 @@ std::vector<Handle(AIS_InteractiveObject)> ToolpathGenerationPipeline::createToo
                 const auto& currentMove = movements[i];
                 const auto& nextMove = movements[i + 1];
                 
-                gp_Pnt start(currentMove.position.x, currentMove.position.y, currentMove.position.z);
-                gp_Pnt end(nextMove.position.x, nextMove.position.y, nextMove.position.z);
+                // Movements are stored with axial position in the X component
+                // and radial position in the Z component.  Convert them to the
+                // standard lathe viewer coordinates where X is radius and Z is
+                // axial.
+                gp_Pnt start(currentMove.position.z, currentMove.position.y, currentMove.position.x);
+                gp_Pnt end(nextMove.position.z, nextMove.position.y, nextMove.position.x);
                 
                 if (start.Distance(end) > Precision::Confusion()) {
                     BRepBuilderAPI_MakeEdge edgeBuilder(start, end);


### PR DESCRIPTION
## Summary
- correct axis/diameter swap in ToolpathGenerationPipeline
- draw ToolpathDisplayObject moves using converted lathe coordinates

## Testing
- `cmake -S . -B build` *(fails: Could not find a package configuration file provided by "Qt6"*)

------
https://chatgpt.com/codex/tasks/task_e_686fb8ff591083328190405d2416b133