### PR TITLE
Fix toolpath coordinate orientation

### DIFF
--- a/core/toolpath/src/ChamferingOperation.cpp
+++ b/core/toolpath/src/ChamferingOperation.cpp
@@ -104,19 +104,19 @@ std::unique_ptr<Toolpath> ChamferingOperation::generateLinearChamfer() {
     }
     
     // Rapid to safe position
-    toolpath->addRapidMove(Geometry::Point3D(safeZ, 0.0, chamferStartR + 2.0));
+    toolpath->addRapidMove(Geometry::Point3D(chamferStartR + 2.0, 0.0, safeZ));
     
     // Position to start of chamfer
-    toolpath->addRapidMove(Geometry::Point3D(chamferStartZ + 1.0, 0.0, chamferStartR));
+    toolpath->addRapidMove(Geometry::Point3D(chamferStartR, 0.0, chamferStartZ + 1.0));
     
     // Feed to chamfer start
-    toolpath->addLinearMove(Geometry::Point3D(chamferStartZ, 0.0, chamferStartR), params_.feedRate);
+    toolpath->addLinearMove(Geometry::Point3D(chamferStartR, 0.0, chamferStartZ), params_.feedRate);
     
     // Cut chamfer
-    toolpath->addLinearMove(Geometry::Point3D(chamferEndZ, 0.0, chamferEndR), params_.feedRate);
+    toolpath->addLinearMove(Geometry::Point3D(chamferEndR, 0.0, chamferEndZ), params_.feedRate);
     
     // Retract to safe position
-    toolpath->addRapidMove(Geometry::Point3D(safeZ, 0.0, chamferEndR));
+    toolpath->addRapidMove(Geometry::Point3D(chamferEndR, 0.0, safeZ));
     
     return toolpath;
 }
@@ -132,7 +132,7 @@ std::unique_ptr<Toolpath> ChamferingOperation::generateRadiusChamfer() {
     double radius = params_.chamferSize;
     
     // Rapid to safe position
-    toolpath->addRapidMove(Geometry::Point3D(safeZ, 0.0, startRadius + 2.0));
+    toolpath->addRapidMove(Geometry::Point3D(startRadius + 2.0, 0.0, safeZ));
     
     // Generate arc segments
     for (int i = 0; i <= segments; i++) {
@@ -144,17 +144,17 @@ std::unique_ptr<Toolpath> ChamferingOperation::generateRadiusChamfer() {
         
         if (i == 0) {
             // Position to start
-            toolpath->addRapidMove(Geometry::Point3D(z + 1.0, 0.0, r));
-            toolpath->addLinearMove(Geometry::Point3D(z, 0.0, r), params_.feedRate);
+            toolpath->addRapidMove(Geometry::Point3D(r, 0.0, z + 1.0));
+            toolpath->addLinearMove(Geometry::Point3D(r, 0.0, z), params_.feedRate);
         } else {
             // Cut arc segment
-            toolpath->addLinearMove(Geometry::Point3D(z, 0.0, r), params_.feedRate);
+            toolpath->addLinearMove(Geometry::Point3D(r, 0.0, z), params_.feedRate);
         }
     }
     
     // Retract to safe position
     double finalR = startRadius - radius;
-    toolpath->addRapidMove(Geometry::Point3D(safeZ, 0.0, finalR));
+    toolpath->addRapidMove(Geometry::Point3D(finalR, 0.0, safeZ));
     
     return toolpath;
 }

--- a/core/toolpath/src/ContouringOperation.cpp
+++ b/core/toolpath/src/ContouringOperation.cpp
@@ -212,37 +212,37 @@ std::unique_ptr<Toolpath> ContouringOperation::generateFacingPass(
     
     // Rapid to start position (safe height above face)
     gp_Pnt startPos(maxZ + params.safetyHeight, 0.0, currentRadius);
-    toolpath->addRapidMove(Geometry::Point3D(startPos.X(), startPos.Y(), startPos.Z()));
+    toolpath->addRapidMove(Geometry::Point3D(startPos.Z(), startPos.Y(), startPos.X()));
     
     // Rapid down to clearance
     gp_Pnt clearancePos(maxZ + params.clearanceDistance, 0.0, currentRadius);
-    toolpath->addRapidMove(Geometry::Point3D(clearancePos.X(), clearancePos.Y(), clearancePos.Z()));
+    toolpath->addRapidMove(Geometry::Point3D(clearancePos.Z(), clearancePos.Y(), clearancePos.X()));
     
     // Generate facing passes
     while (currentRadius > 0.1) { // Stop near center
         // Feed to face
         gp_Pnt faceStart(maxZ, 0.0, currentRadius);
         toolpath->addLinearMove(
-            Geometry::Point3D(faceStart.X(), faceStart.Y(), faceStart.Z()),
+            Geometry::Point3D(faceStart.Z(), faceStart.Y(), faceStart.X()),
             tool->getCuttingParameters().feedRate * 60.0); // Convert mm/rev to mm/min
         
         // Face across to center (or inner radius)
         double targetRadius = std::max(0.0, currentRadius - facingDepth);
         gp_Pnt faceEnd(maxZ, 0.0, targetRadius);
         toolpath->addLinearMove(
-            Geometry::Point3D(faceEnd.X(), faceEnd.Y(), faceEnd.Z()),
+            Geometry::Point3D(faceEnd.Z(), faceEnd.Y(), faceEnd.X()),
             tool->getCuttingParameters().feedRate * 60.0); // Convert mm/rev to mm/min
         
         // Rapid back to clearance
         gp_Pnt retractPos(maxZ + params.clearanceDistance, 0.0, targetRadius);
-        toolpath->addRapidMove(Geometry::Point3D(retractPos.X(), retractPos.Y(), retractPos.Z()));
+        toolpath->addRapidMove(Geometry::Point3D(retractPos.Z(), retractPos.Y(), retractPos.X()));
         
         currentRadius = targetRadius;
     }
     
     // Return to safe position
     gp_Pnt safePos(maxZ + params.safetyHeight, 0.0, 0.0);
-    toolpath->addRapidMove(Geometry::Point3D(safePos.X(), safePos.Y(), safePos.Z()));
+    toolpath->addRapidMove(Geometry::Point3D(safePos.Z(), safePos.Y(), safePos.X()));
     
     return toolpath;
 }
@@ -276,7 +276,7 @@ std::unique_ptr<Toolpath> ContouringOperation::generateRoughingPass(
     
     // Start from safe position
     gp_Pnt startPos(maxZ + params.safetyHeight, 0.0, maxRadius + params.clearanceDistance);
-    toolpath->addRapidMove(Geometry::Point3D(startPos.X(), startPos.Y(), startPos.Z()));
+    toolpath->addRapidMove(Geometry::Point3D(startPos.Z(), startPos.Y(), startPos.X()));
     
     // Generate roughing passes from outside radius inward
     double currentRadius = maxRadius;
@@ -284,12 +284,12 @@ std::unique_ptr<Toolpath> ContouringOperation::generateRoughingPass(
     while (currentRadius > stockAllowance) {
         // Rapid to start of pass
         gp_Pnt passStart(maxZ + params.clearanceDistance, 0.0, currentRadius);
-        toolpath->addRapidMove(Geometry::Point3D(passStart.X(), passStart.Y(), passStart.Z()));
+        toolpath->addRapidMove(Geometry::Point3D(passStart.Z(), passStart.Y(), passStart.X()));
         
         // Feed down to cutting depth
         gp_Pnt cutStart(maxZ, 0.0, currentRadius);
         toolpath->addLinearMove(
-            Geometry::Point3D(cutStart.X(), cutStart.Y(), cutStart.Z()),
+            Geometry::Point3D(cutStart.Z(), cutStart.Y(), cutStart.X()),
             tool->getCuttingParameters().feedRate * 60.0); // Convert mm/rev to mm/min
         
         // Follow profile with offset for stock allowance
@@ -298,7 +298,7 @@ std::unique_ptr<Toolpath> ContouringOperation::generateRoughingPass(
             if (offsetRadius <= currentRadius) {
                 gp_Pnt cutPoint(point.x, 0.0, offsetRadius);
                 toolpath->addLinearMove(
-                    Geometry::Point3D(cutPoint.X(), cutPoint.Y(), cutPoint.Z()),
+                    Geometry::Point3D(cutPoint.Z(), cutPoint.Y(), cutPoint.X()),
                     tool->getCuttingParameters().feedRate * 60.0); // Convert mm/rev to mm/min
             }
         }
@@ -309,7 +309,7 @@ std::unique_ptr<Toolpath> ContouringOperation::generateRoughingPass(
     
     // Return to safe position
     gp_Pnt endPos(maxZ + params.safetyHeight, 0.0, maxRadius + params.clearanceDistance);
-    toolpath->addRapidMove(Geometry::Point3D(endPos.X(), endPos.Y(), endPos.Z()));
+    toolpath->addRapidMove(Geometry::Point3D(endPos.Z(), endPos.Y(), endPos.X()));
     
     return toolpath;
 }
@@ -336,18 +336,18 @@ std::unique_ptr<Toolpath> ContouringOperation::generateFinishingPass(
     
     // Start from safe position
     gp_Pnt startPos(maxZ + params.safetyHeight, 0.0, maxRadius + params.clearanceDistance);
-    toolpath->addRapidMove(Geometry::Point3D(startPos.X(), startPos.Y(), startPos.Z()));
+    toolpath->addRapidMove(Geometry::Point3D(startPos.Z(), startPos.Y(), startPos.X()));
     
     // Rapid to start of finishing pass
     gp_Pnt finishStart(maxZ + params.clearanceDistance, 0.0, maxRadius);
-    toolpath->addRapidMove(Geometry::Point3D(finishStart.X(), finishStart.Y(), finishStart.Z()));
+    toolpath->addRapidMove(Geometry::Point3D(finishStart.Z(), finishStart.Y(), finishStart.X()));
     
     // Feed to first profile point
     if (!profile.empty()) {
         const auto& firstPoint = profile.front();
         gp_Pnt firstCut(firstPoint.x, 0.0, firstPoint.z);
         toolpath->addLinearMove(
-            Geometry::Point3D(firstCut.X(), firstCut.Y(), firstCut.Z()),
+            Geometry::Point3D(firstCut.Z(), firstCut.Y(), firstCut.X()),
             params.finishingParams.feedRate);
         
         // Follow the exact profile for finishing
@@ -355,14 +355,14 @@ std::unique_ptr<Toolpath> ContouringOperation::generateFinishingPass(
             const auto& point = profile[i];
             gp_Pnt cutPoint(point.x, 0.0, point.z);
             toolpath->addLinearMove(
-                Geometry::Point3D(cutPoint.X(), cutPoint.Y(), cutPoint.Z()),
+                Geometry::Point3D(cutPoint.Z(), cutPoint.Y(), cutPoint.X()),
                 params.finishingParams.feedRate);
         }
     }
     
     // Return to safe position
     gp_Pnt endPos(maxZ + params.safetyHeight, 0.0, maxRadius + params.clearanceDistance);
-    toolpath->addRapidMove(Geometry::Point3D(endPos.X(), endPos.Y(), endPos.Z()));
+    toolpath->addRapidMove(Geometry::Point3D(endPos.Z(), endPos.Y(), endPos.X()));
     
     return toolpath;
 }

--- a/core/toolpath/src/FinishingOperation.cpp
+++ b/core/toolpath/src/FinishingOperation.cpp
@@ -59,22 +59,22 @@ std::unique_ptr<Toolpath> FinishingOperation::generateToolpath(const Geometry::P
     double safeZ = params_.startZ + 5.0; // 5mm clearance
     
     // Safety rapid to start position
-    toolpath->addRapidMove(Geometry::Point3D(safeZ, 0.0, targetRadius));
+    toolpath->addRapidMove(Geometry::Point3D(targetRadius, 0.0, safeZ));
     
     // Rapid to cutting position
-    toolpath->addRapidMove(Geometry::Point3D(currentZ + 1.0, 0.0, targetRadius));
+    toolpath->addRapidMove(Geometry::Point3D(targetRadius, 0.0, currentZ + 1.0));
     
     // Feed to cutting depth
-    toolpath->addLinearMove(Geometry::Point3D(currentZ, 0.0, targetRadius), params_.feedRate * 60.0);
+    toolpath->addLinearMove(Geometry::Point3D(targetRadius, 0.0, currentZ), params_.feedRate * 60.0);
     
     // Finish down to end Z in single pass
-    toolpath->addLinearMove(Geometry::Point3D(endZ, 0.0, targetRadius), params_.feedRate * 60.0);
+    toolpath->addLinearMove(Geometry::Point3D(targetRadius, 0.0, endZ), params_.feedRate * 60.0);
     
     // Retract
-    toolpath->addRapidMove(Geometry::Point3D(endZ - 1.0, 0.0, targetRadius));
+    toolpath->addRapidMove(Geometry::Point3D(targetRadius, 0.0, endZ - 1.0));
     
     // Return to safe position
-    toolpath->addRapidMove(Geometry::Point3D(safeZ, 0.0, targetRadius));
+    toolpath->addRapidMove(Geometry::Point3D(targetRadius, 0.0, safeZ));
     
     return toolpath;
 }

--- a/core/toolpath/src/PartingOperation.cpp
+++ b/core/toolpath/src/PartingOperation.cpp
@@ -344,7 +344,7 @@ std::unique_ptr<Toolpath> PartingOperation::generateStraightParting(
     
     // Start from safe position
     gp_Pnt safeStart(partingZ + params.safetyHeight, 0.0, outerRadius + params.clearanceDistance);
-    toolpath->addRapidMove(Geometry::Point3D(safeStart.X(), safeStart.Y(), safeStart.Z()));
+    toolpath->addRapidMove(Geometry::Point3D(safeStart.Z(), safeStart.Y(), safeStart.X()));
     
     // Calculate pass depths
     double totalDepth = outerRadius - innerRadius;
@@ -364,18 +364,18 @@ std::unique_ptr<Toolpath> PartingOperation::generateStraightParting(
         
         // Rapid to start of cut
         gp_Pnt cutStart(partingZ + params.clearanceDistance, 0.0, currentRadius);
-        toolpath->addRapidMove(Geometry::Point3D(cutStart.X(), cutStart.Y(), cutStart.Z()));
+        toolpath->addRapidMove(Geometry::Point3D(cutStart.Z(), cutStart.Y(), cutStart.X()));
         
         // Feed to cutting position
         gp_Pnt feedStart(partingZ, 0.0, currentRadius);
         toolpath->addLinearMove(
-            Geometry::Point3D(feedStart.X(), feedStart.Y(), feedStart.Z()),
+            Geometry::Point3D(feedStart.Z(), feedStart.Y(), feedStart.X()),
             params.feedRate);
         
         // Parting cut
         gp_Pnt cutEnd(partingZ, 0.0, targetRadius);
         toolpath->addLinearMove(
-            Geometry::Point3D(cutEnd.X(), cutEnd.Y(), cutEnd.Z()),
+            Geometry::Point3D(cutEnd.Z(), cutEnd.Y(), cutEnd.X()),
             params.feedRate);
         
         // Chip breaking if enabled
@@ -386,12 +386,12 @@ std::unique_ptr<Toolpath> PartingOperation::generateStraightParting(
                     // Retract slightly for chip breaking
                     gp_Pnt chipBreak(partingZ, 0.0, breakRadius + params.chipBreakDistance);
                     toolpath->addLinearMove(
-                        Geometry::Point3D(chipBreak.X(), chipBreak.Y(), chipBreak.Z()),
+                        Geometry::Point3D(chipBreak.Z(), chipBreak.Y(), chipBreak.X()),
                         params.feedRate * 2.0);
                     
                     // Return to cutting
                     toolpath->addLinearMove(
-                        Geometry::Point3D(cutEnd.X(), cutEnd.Y(), cutEnd.Z()),
+                        Geometry::Point3D(cutEnd.Z(), cutEnd.Y(), cutEnd.X()),
                         params.feedRate);
                 }
             }
@@ -399,12 +399,12 @@ std::unique_ptr<Toolpath> PartingOperation::generateStraightParting(
         
         // Retract to safe radius
         gp_Pnt retract(partingZ + params.retractDistance, 0.0, targetRadius);
-        toolpath->addRapidMove(Geometry::Point3D(retract.X(), retract.Y(), retract.Z()));
+        toolpath->addRapidMove(Geometry::Point3D(retract.Z(), retract.Y(), retract.X()));
     }
     
     // Final retract to safe position
     gp_Pnt finalSafe(partingZ + params.safetyHeight, 0.0, outerRadius + params.clearanceDistance);
-    toolpath->addRapidMove(Geometry::Point3D(finalSafe.X(), finalSafe.Y(), finalSafe.Z()));
+    toolpath->addRapidMove(Geometry::Point3D(finalSafe.Z(), finalSafe.Y(), finalSafe.X()));
     
     return toolpath;
 }
@@ -424,7 +424,7 @@ std::unique_ptr<Toolpath> PartingOperation::generateSteppedParting(
     
     // Start from safe position
     gp_Pnt safeStart(partingZ + params.safetyHeight, 0.0, outerRadius + params.clearanceDistance);
-    toolpath->addRapidMove(Geometry::Point3D(safeStart.X(), safeStart.Y(), safeStart.Z()));
+    toolpath->addRapidMove(Geometry::Point3D(safeStart.Z(), safeStart.Y(), safeStart.X()));
     
     // Generate stepped cuts
     double currentRadius = outerRadius;
@@ -443,23 +443,23 @@ std::unique_ptr<Toolpath> PartingOperation::generateSteppedParting(
             
             // Rapid to cutting position
             gp_Pnt cutStart(partingZ + params.clearanceDistance, 0.0, passStartRadius);
-            toolpath->addRapidMove(Geometry::Point3D(cutStart.X(), cutStart.Y(), cutStart.Z()));
+            toolpath->addRapidMove(Geometry::Point3D(cutStart.Z(), cutStart.Y(), cutStart.X()));
             
             // Feed to cutting depth
             gp_Pnt feedStart(partingZ, 0.0, passStartRadius);
             toolpath->addLinearMove(
-                Geometry::Point3D(feedStart.X(), feedStart.Y(), feedStart.Z()),
+                Geometry::Point3D(feedStart.Z(), feedStart.Y(), feedStart.X()),
                 params.feedRate);
             
             // Cutting move
             gp_Pnt cutEnd(partingZ, 0.0, passEndRadius);
             toolpath->addLinearMove(
-                Geometry::Point3D(cutEnd.X(), cutEnd.Y(), cutEnd.Z()),
+                Geometry::Point3D(cutEnd.Z(), cutEnd.Y(), cutEnd.X()),
                 params.feedRate);
             
             // Retract
             gp_Pnt retract(partingZ + params.retractDistance, 0.0, passEndRadius);
-            toolpath->addRapidMove(Geometry::Point3D(retract.X(), retract.Y(), retract.Z()));
+            toolpath->addRapidMove(Geometry::Point3D(retract.Z(), retract.Y(), retract.X()));
         }
         
         currentRadius = targetRadius;
@@ -471,7 +471,7 @@ std::unique_ptr<Toolpath> PartingOperation::generateSteppedParting(
     
     // Final safe position
     gp_Pnt finalSafe(partingZ + params.safetyHeight, 0.0, outerRadius + params.clearanceDistance);
-    toolpath->addRapidMove(Geometry::Point3D(finalSafe.X(), finalSafe.Y(), finalSafe.Z()));
+    toolpath->addRapidMove(Geometry::Point3D(finalSafe.Z(), finalSafe.Y(), finalSafe.X()));
     
     return toolpath;
 }
@@ -490,16 +490,16 @@ std::unique_ptr<Toolpath> PartingOperation::generateGrooveRelief(
     gp_Pnt grooveEnd(grooveZ, 0.0, grooveRadius);
     
     // Rapid to groove start
-    toolpath->addRapidMove(Geometry::Point3D(grooveStart.X(), grooveStart.Y(), grooveStart.Z()));
+    toolpath->addRapidMove(Geometry::Point3D(grooveStart.Z(), grooveStart.Y(), grooveStart.X()));
     
     // Cut groove
     toolpath->addLinearMove(
-        Geometry::Point3D(grooveEnd.X(), grooveEnd.Y(), grooveEnd.Z()),
+        Geometry::Point3D(grooveEnd.Z(), grooveEnd.Y(), grooveEnd.X()),
         params.feedRate * 0.8); // Slower for grooving
     
     // Retract
     gp_Pnt retract(grooveZ + params.retractDistance, 0.0, grooveRadius);
-    toolpath->addRapidMove(Geometry::Point3D(retract.X(), retract.Y(), retract.Z()));
+    toolpath->addRapidMove(Geometry::Point3D(retract.Z(), retract.Y(), retract.X()));
     
     return toolpath;
 }
@@ -522,15 +522,15 @@ std::unique_ptr<Toolpath> PartingOperation::generateUndercutParting(
     
     // Start position
     gp_Pnt safeStart(partingZ + params.safetyHeight, 0.0, outerRadius + params.clearanceDistance);
-    toolpath->addRapidMove(Geometry::Point3D(safeStart.X(), safeStart.Y(), safeStart.Z()));
+    toolpath->addRapidMove(Geometry::Point3D(safeStart.Z(), safeStart.Y(), safeStart.X()));
     
     // Create undercut first
     gp_Pnt undercutStart(partingZ + undercutOffset, 0.0, outerRadius);
     gp_Pnt undercutEnd(partingZ, 0.0, outerRadius - undercutDepth);
     
-    toolpath->addRapidMove(Geometry::Point3D(undercutStart.X(), undercutStart.Y(), undercutStart.Z()));
+    toolpath->addRapidMove(Geometry::Point3D(undercutStart.Z(), undercutStart.Y(), undercutStart.X()));
     toolpath->addLinearMove(
-        Geometry::Point3D(undercutEnd.X(), undercutEnd.Y(), undercutEnd.Z()),
+        Geometry::Point3D(undercutEnd.Z(), undercutEnd.Y(), undercutEnd.X()),
         params.feedRate);
     
     // Continue with normal parting from undercut position
@@ -540,7 +540,7 @@ std::unique_ptr<Toolpath> PartingOperation::generateUndercutParting(
         
         gp_Pnt cutEnd(partingZ, 0.0, targetRadius);
         toolpath->addLinearMove(
-            Geometry::Point3D(cutEnd.X(), cutEnd.Y(), cutEnd.Z()),
+            Geometry::Point3D(cutEnd.Z(), cutEnd.Y(), cutEnd.X()),
             params.feedRate);
         
         currentRadius = targetRadius;
@@ -548,7 +548,7 @@ std::unique_ptr<Toolpath> PartingOperation::generateUndercutParting(
     
     // Final retract
     gp_Pnt finalSafe(partingZ + params.safetyHeight, 0.0, outerRadius + params.clearanceDistance);
-    toolpath->addRapidMove(Geometry::Point3D(finalSafe.X(), finalSafe.Y(), finalSafe.Z()));
+    toolpath->addRapidMove(Geometry::Point3D(finalSafe.Z(), finalSafe.Y(), finalSafe.X()));
     
     return toolpath;
 }
@@ -570,9 +570,9 @@ std::unique_ptr<Toolpath> PartingOperation::generateTrepanningParting(
         gp_Pnt grooveStart(z, 0.0, outerRadius);
         gp_Pnt grooveEnd(z, 0.0, outerRadius - params.depthOfCut);
         
-        toolpath->addRapidMove(Geometry::Point3D(grooveStart.X(), grooveStart.Y(), grooveStart.Z()));
+        toolpath->addRapidMove(Geometry::Point3D(grooveStart.Z(), grooveStart.Y(), grooveStart.X()));
         toolpath->addLinearMove(
-            Geometry::Point3D(grooveEnd.X(), grooveEnd.Y(), grooveEnd.Z()),
+            Geometry::Point3D(grooveEnd.Z(), grooveEnd.Y(), grooveEnd.X()),
             params.feedRate * 0.7);
     }
     
@@ -584,9 +584,9 @@ std::unique_ptr<Toolpath> PartingOperation::generateTrepanningParting(
         gp_Pnt cutStart(partingZ, 0.0, remainingRadius);
         gp_Pnt cutEnd(partingZ, 0.0, targetRadius);
         
-        toolpath->addRapidMove(Geometry::Point3D(cutStart.X(), cutStart.Y(), cutStart.Z()));
+        toolpath->addRapidMove(Geometry::Point3D(cutStart.Z(), cutStart.Y(), cutStart.X()));
         toolpath->addLinearMove(
-            Geometry::Point3D(cutEnd.X(), cutEnd.Y(), cutEnd.Z()),
+            Geometry::Point3D(cutEnd.Z(), cutEnd.Y(), cutEnd.X()),
             params.feedRate);
         
         remainingRadius = targetRadius;
@@ -610,9 +610,9 @@ std::unique_ptr<Toolpath> PartingOperation::generateFinishingPass(
     gp_Pnt finishStart(partingZ, 0.0, outerRadius - params.finishingAllowance);
     gp_Pnt finishEnd(partingZ, 0.0, innerRadius);
     
-    toolpath->addRapidMove(Geometry::Point3D(finishStart.X(), finishStart.Y(), finishStart.Z()));
+    toolpath->addRapidMove(Geometry::Point3D(finishStart.Z(), finishStart.Y(), finishStart.X()));
     toolpath->addLinearMove(
-        Geometry::Point3D(finishEnd.X(), finishEnd.Y(), finishEnd.Z()),
+        Geometry::Point3D(finishEnd.Z(), finishEnd.Y(), finishEnd.X()),
         params.finishingFeedRate);
     
     return toolpath;


### PR DESCRIPTION
## Summary
- keep toolpaths aligned with lathe coordinate system
- swap X/Z when creating toolpath points in facing, roughing, finishing,
  chamfering, contouring and parting operations

## Testing
- `ctest --output-on-failure`

------
https://chatgpt.com/codex/tasks/task_e_686fbcaf66308332959109c298fd1b89