### PR TITLE
Fix toolpath geometry sync

### DIFF
--- a/gui/include/workpiecemanager.h
+++ b/gui/include/workpiecemanager.h
@@ -123,6 +123,16 @@ public:
     TopoDS_Shape getWorkpieceShape() const;
 
     /**
+     * @brief Get the shape of the current workpiece with all active
+     *        transformations (alignment, flipping and positioning) applied.
+     *
+     * This is useful when the raw geometry needs to be processed by
+     * algorithms that expect it to be in the same position as displayed in
+     * the viewer, e.g. toolpath generation or profile extraction.
+     */
+    TopoDS_Shape getTransformedWorkpieceShape() const;
+
+    /**
      * @brief Get the main cylinder axis from the current workpiece
      */
     gp_Ax1 getMainCylinderAxis() const { return m_mainCylinderAxis; }

--- a/gui/src/workpiecemanager.cpp
+++ b/gui/src/workpiecemanager.cpp
@@ -28,6 +28,7 @@
 #include <TopoDS_Edge.hxx>
 #include <BRepAdaptor_Curve.hxx>
 #include <GeomAbs_CurveType.hxx>
+#include <BRepBuilderAPI_Transform.hxx>
 #include <gp_Circ.hxx>
 #include <BRep_Tool.hxx>
 #include <TopExp.hxx>
@@ -660,9 +661,22 @@ TopoDS_Shape WorkpieceManager::getWorkpieceShape() const
             return aisShape->Shape();
         }
     }
-    
+
     // Return null shape if no workpiece or invalid shape
     return TopoDS_Shape();
+}
+
+TopoDS_Shape WorkpieceManager::getTransformedWorkpieceShape() const
+{
+    TopoDS_Shape shape = getWorkpieceShape();
+    if (shape.IsNull()) {
+        return shape;
+    }
+
+    // Apply the current transformation stack (axis alignment, flip, positioning)
+    gp_Trsf transform = getCurrentTransformation();
+    BRepBuilderAPI_Transform transformer(shape, transform, true);
+    return transformer.Shape();
 }
 
 double WorkpieceManager::getLargestCircularEdgeDiameter(const TopoDS_Shape& workpiece) const

--- a/gui/src/workspacecontroller.cpp
+++ b/gui/src/workspacecontroller.cpp
@@ -844,9 +844,11 @@ bool WorkspaceController::hasPartShape() const
 
 TopoDS_Shape WorkspaceController::getPartShape() const
 {
-    // If we have a workpiece manager and it has a part, return it
+    // If we have a workpiece manager and it has a part, return it with the
+    // current transformation applied so that downstream processing operates on
+    // geometry positioned exactly as displayed in the viewer.
     if (m_workpieceManager && m_workpieceManager->hasWorkpiece()) {
-        return m_workpieceManager->getWorkpieceShape();
+        return m_workpieceManager->getTransformedWorkpieceShape();
     }
     
     // Otherwise return a null shape
@@ -907,7 +909,7 @@ bool WorkspaceController::generateToolpaths()
     try {
         qDebug() << "WorkspaceController: Starting toolpath generation";
         
-        // Get the current part shape
+        // Get the current part shape with all transformations applied
         TopoDS_Shape partShape = getPartShape();
         
         // Create the toolpath generation pipeline


### PR DESCRIPTION
## Summary
- transform workpiece geometry before generating toolpaths
- expose `getTransformedWorkpieceShape` in `WorkpieceManager`
- use the transformed part shape in `WorkspaceController`

## Testing
- `cmake --preset ninja-release` *(fails: toolchain file not found)*
- `ctest --preset ninja-release` *(fails: No tests were found)*

------
https://chatgpt.com/codex/tasks/task_e_6870158891888332a102911be4f3858e