### PR TITLE
Fix pipeline toolpath generation using part geometry

### DIFF
--- a/core/toolpath/src/FinishingOperation.cpp
+++ b/core/toolpath/src/FinishingOperation.cpp
@@ -107,9 +107,13 @@ std::unique_ptr<Toolpath> FinishingOperation::generateToolpath(const Geometry::P
     extractParams.turningAxis = gp_Ax1(gp_Pnt(0, 0, 0), gp_Dir(0, 0, 1)); // Standard lathe Z-axis
     extractParams.sortSegments = true;                         // Ensure proper ordering
     
-    // Get part shape for profile extraction
-    // Note: In real implementation, this would be extracted from Geometry::Part
-    TopoDS_Shape partShape; // This would come from part.getShape() or similar
+    // Get part shape for profile extraction from the provided Geometry::Part
+    TopoDS_Shape partShape;
+    const Geometry::OCCTPart* occtPart = dynamic_cast<const Geometry::OCCTPart*>(&part);
+    if (occtPart) {
+        partShape = occtPart->getOCCTShape();
+    }
+
     auto profile = ProfileExtractor::extractProfile(partShape, extractParams);
     
     if (profile.isEmpty()) {

--- a/core/toolpath/src/PartingOperation.cpp
+++ b/core/toolpath/src/PartingOperation.cpp
@@ -43,7 +43,12 @@ PartingOperation::Result PartingOperation::generateToolpaths(
         extractParams.turningAxis = gp_Ax1(gp_Pnt(0, 0, 0), gp_Dir(0, 0, 1));
         extractParams.sortSegments = true;                          // Ensure proper ordering
         
-        TopoDS_Shape partShape; // This would come from the Part object
+        // Use the actual part geometry for profile extraction
+        TopoDS_Shape partShape;
+        const Geometry::OCCTPart* occtPart = dynamic_cast<const Geometry::OCCTPart*>(&part);
+        if (occtPart) {
+            partShape = occtPart->getOCCTShape();
+        }
         auto profile = ProfileExtractor::extractProfile(partShape, extractParams);
         
         // Detect potential parting positions if not explicitly specified

--- a/core/toolpath/src/ToolpathGenerationPipeline.cpp
+++ b/core/toolpath/src/ToolpathGenerationPipeline.cpp
@@ -786,13 +786,21 @@ std::vector<std::unique_ptr<Toolpath>> ToolpathGenerationPipeline::internalFinis
     params.maxSpindleSpeed = 1500.0;  // RPM - Default GUI parameter
     
     finishingOp.setParameters(params);
-    
+
     // Create an empty Part object for generateToolpath
     auto part = createPartFromGeometry();
-    
+
     // Generate toolpath using the operation
     auto toolpath = finishingOp.generateToolpath(*part);
     if (toolpath) {
+        toolpath->setOperationType(OperationType::InternalFinishing);
+
+        auto& movements = const_cast<std::vector<Movement>&>(toolpath->getMovements());
+        for (auto& movement : movements) {
+            movement.operationType = OperationType::InternalFinishing;
+            movement.operationName = "Internal Finishing";
+        }
+
         result.push_back(std::move(toolpath));
     }
     
@@ -834,10 +842,18 @@ std::vector<std::unique_ptr<Toolpath>> ToolpathGenerationPipeline::externalFinis
     
     // Create an empty Part object for generateToolpath
     auto part = createPartFromGeometry();
-    
+
     // Generate toolpath using the operation
     auto toolpath = finishingOp.generateToolpath(*part);
     if (toolpath) {
+        toolpath->setOperationType(OperationType::ExternalFinishing);
+
+        auto& movements = const_cast<std::vector<Movement>&>(toolpath->getMovements());
+        for (auto& movement : movements) {
+            movement.operationType = OperationType::ExternalFinishing;
+            movement.operationName = "External Finishing";
+        }
+
         result.push_back(std::move(toolpath));
     }
     
@@ -1229,18 +1245,36 @@ std::vector<std::unique_ptr<Toolpath>> ToolpathGenerationPipeline::partingToolpa
     
     // Create an empty Part object for generateToolpaths
     auto part = createPartFromGeometry();
-    
+
     // Generate toolpaths using the operation (note: different interface)
     auto partingResult = partingOp.generateToolpaths(*part, tool, params);
-    
+
     if (partingResult.success) {
         if (partingResult.grooveToolpath) {
+            partingResult.grooveToolpath->setOperationType(OperationType::Parting);
+            auto& mv = const_cast<std::vector<Movement>&>(partingResult.grooveToolpath->getMovements());
+            for (auto& m : mv) {
+                m.operationType = OperationType::Parting;
+                m.operationName = "Parting";
+            }
             result.push_back(std::move(partingResult.grooveToolpath));
         }
         if (partingResult.partingToolpath) {
+            partingResult.partingToolpath->setOperationType(OperationType::Parting);
+            auto& mv = const_cast<std::vector<Movement>&>(partingResult.partingToolpath->getMovements());
+            for (auto& m : mv) {
+                m.operationType = OperationType::Parting;
+                m.operationName = "Parting";
+            }
             result.push_back(std::move(partingResult.partingToolpath));
         }
         if (partingResult.finishingToolpath) {
+            partingResult.finishingToolpath->setOperationType(OperationType::Parting);
+            auto& mv = const_cast<std::vector<Movement>&>(partingResult.finishingToolpath->getMovements());
+            for (auto& m : mv) {
+                m.operationType = OperationType::Parting;
+                m.operationName = "Parting";
+            }
             result.push_back(std::move(partingResult.finishingToolpath));
         }
     }


### PR DESCRIPTION
## Summary
- use actual part geometry when generating finishing and parting toolpaths
- set operation type for finishing and parting toolpaths
- update movements to carry the correct operation metadata

## Testing
- `g++ tests/test_core.cpp -I./core/common/include -I./core/geometry/include -std=c++17 -o test_core && ./test_core`

------
https://chatgpt.com/codex/tasks/task_e_68701ec0b36483329d52f6130f7b8ceb