### PR TITLE
Fix toolpath offset

### DIFF
--- a/core/toolpath/src/ToolpathGenerationPipeline.cpp
+++ b/core/toolpath/src/ToolpathGenerationPipeline.cpp
@@ -1158,7 +1158,30 @@ std::vector<std::unique_ptr<Toolpath>> ToolpathGenerationPipeline::partingToolpa
 std::vector<Handle(AIS_InteractiveObject)> ToolpathGenerationPipeline::createToolpathDisplayObjects(
     const std::vector<std::unique_ptr<Toolpath>>& toolpaths,
     const gp_Trsf& workpieceTransform) {
-    
+
+    auto trsfToMatrix = [](const gp_Trsf& trsf) {
+        IntuiCAM::Geometry::Matrix4x4 mat;
+        mat.data[0] = trsf.Value(1, 1);
+        mat.data[1] = trsf.Value(1, 2);
+        mat.data[2] = trsf.Value(1, 3);
+        mat.data[3] = 0.0;
+        mat.data[4] = trsf.Value(2, 1);
+        mat.data[5] = trsf.Value(2, 2);
+        mat.data[6] = trsf.Value(2, 3);
+        mat.data[7] = 0.0;
+        mat.data[8] = trsf.Value(3, 1);
+        mat.data[9] = trsf.Value(3, 2);
+        mat.data[10] = trsf.Value(3, 3);
+        mat.data[11] = 0.0;
+        mat.data[12] = trsf.Value(1, 4);
+        mat.data[13] = trsf.Value(2, 4);
+        mat.data[14] = trsf.Value(3, 4);
+        mat.data[15] = 1.0;
+        return mat;
+    };
+
+    IntuiCAM::Geometry::Matrix4x4 transformMatrix = trsfToMatrix(workpieceTransform);
+
     std::vector<Handle(AIS_InteractiveObject)> displayObjects;
     
     // Create proper ToolpathDisplayObject instances for each toolpath
@@ -1234,7 +1257,10 @@ std::vector<Handle(AIS_InteractiveObject)> ToolpathGenerationPipeline::createToo
             for (const auto& movement : movements) {
                 newToolpath->addMovement(movement);
             }
-            
+
+            // Apply positioning transform
+            newToolpath->applyTransform(transformMatrix);
+
             sharedToolpath = newToolpath;
             
             // Create the ToolpathDisplayObject

--- a/gui/src/workspacecontroller.cpp
+++ b/gui/src/workspacecontroller.cpp
@@ -1055,13 +1055,14 @@ bool WorkspaceController::generateToolpaths()
         if (m_coordinateManager && m_coordinateManager->isInitialized()) {
             // Get work coordinate system transformation matrix
             const auto& workCS = m_coordinateManager->getWorkCoordinateSystem();
-            const auto& matrix = workCS.getFromGlobalMatrix(); // Transform from global to work coordinates
+            // Use work to global matrix so toolpaths align with raw material
+            const auto& matrix = workCS.getToGlobalMatrix();
             
             // Create OpenCASCADE transformation matrix from work coordinate system
             workCoordinateTransform.SetValues(
-                matrix.data[0], matrix.data[1], matrix.data[2], matrix.data[3],
-                matrix.data[4], matrix.data[5], matrix.data[6], matrix.data[7],
-                matrix.data[8], matrix.data[9], matrix.data[10], matrix.data[11]
+                matrix.data[0], matrix.data[1], matrix.data[2], matrix.data[12],
+                matrix.data[4], matrix.data[5], matrix.data[6], matrix.data[13],
+                matrix.data[8], matrix.data[9], matrix.data[10], matrix.data[14]
             );
             qDebug() << "WorkspaceController: Using work coordinate system transformation for toolpath positioning";
         } else {


### PR DESCRIPTION
## Summary
- respect workpiece transform when creating toolpath display objects
- use correct matrix when positioning toolpaths in the viewer

## Testing
- `cmake -S . -B build -DINTUICAM_BUILD_GUI=OFF -DINTUICAM_BUILD_PYTHON=OFF -DINTUICAM_BUILD_TESTS=ON` *(fails: Qt6 not found)*

------
https://chatgpt.com/codex/tasks/task_e_6878cadd8d048332ac1c12d8e4797041