### PR TITLE
Fix toolpath alignment with raw material

### DIFF
--- a/core/toolpath/include/IntuiCAM/Toolpath/ToolpathGenerationPipeline.h
+++ b/core/toolpath/include/IntuiCAM/Toolpath/ToolpathGenerationPipeline.h
@@ -12,6 +12,7 @@
 #include <TopoDS_Shape.hxx>
 #include <gp_Ax1.hxx>
 #include <AIS_InteractiveObject.hxx>
+#include <gp_Trsf.hxx>
 
 // IntuiCAM includes
 #include <IntuiCAM/Toolpath/Types.h>
@@ -212,7 +213,12 @@ private:
         bool chamferEdges);
 
 public:
-    // Public helper methods for toolpath display 
+    // Public helper methods for toolpath display
+    /**
+     * @brief Convert toolpaths to display objects using the provided transform.
+     * @param toolpaths Toolpaths expressed in work coordinates.
+     * @param workpieceTransform Transform from work coordinates to global space.
+     */
     std::vector<Handle(AIS_InteractiveObject)> createToolpathDisplayObjects(
         const std::vector<std::unique_ptr<Toolpath>>& toolpaths,
         const gp_Trsf& workpieceTransform = gp_Trsf());

--- a/core/toolpath/src/ToolpathGenerationPipeline.cpp
+++ b/core/toolpath/src/ToolpathGenerationPipeline.cpp
@@ -28,6 +28,7 @@
 #include <BRepBuilderAPI_Transform.hxx>
 #include <BRepBndLib.hxx>
 #include <Bnd_Box.hxx>
+#include <gp_Trsf.hxx>
 #include <TopoDS_Wire.hxx>
 #include <TopoDS_Shape.hxx>
 #include <TopoDS.hxx>
@@ -1160,6 +1161,30 @@ std::vector<Handle(AIS_InteractiveObject)> ToolpathGenerationPipeline::createToo
     const gp_Trsf& workpieceTransform) {
     
     std::vector<Handle(AIS_InteractiveObject)> displayObjects;
+
+    // Helper to convert gp_Trsf to Geometry::Matrix4x4
+    auto trsfToMatrix = [](const gp_Trsf& trsf) {
+        Geometry::Matrix4x4 mat;
+        mat.data[0] = trsf.Value(1, 1);
+        mat.data[1] = trsf.Value(1, 2);
+        mat.data[2] = trsf.Value(1, 3);
+        mat.data[3] = 0.0;
+        mat.data[4] = trsf.Value(2, 1);
+        mat.data[5] = trsf.Value(2, 2);
+        mat.data[6] = trsf.Value(2, 3);
+        mat.data[7] = 0.0;
+        mat.data[8] = trsf.Value(3, 1);
+        mat.data[9] = trsf.Value(3, 2);
+        mat.data[10] = trsf.Value(3, 3);
+        mat.data[11] = 0.0;
+        mat.data[12] = trsf.TranslationPart().X();
+        mat.data[13] = trsf.TranslationPart().Y();
+        mat.data[14] = trsf.TranslationPart().Z();
+        mat.data[15] = 1.0;
+        return mat;
+    };
+
+    Geometry::Matrix4x4 transformMatrix = trsfToMatrix(workpieceTransform);
     
     // Create proper ToolpathDisplayObject instances for each toolpath
     for (const auto& toolpath : toolpaths) {
@@ -1234,6 +1259,9 @@ std::vector<Handle(AIS_InteractiveObject)> ToolpathGenerationPipeline::createToo
             for (const auto& movement : movements) {
                 newToolpath->addMovement(movement);
             }
+
+            // Apply workpiece transformation so toolpaths align with raw material
+            newToolpath->applyTransform(transformMatrix);
             
             sharedToolpath = newToolpath;
             


### PR DESCRIPTION
## Summary
- apply transformation to toolpath movements when creating display objects
- convert `gp_Trsf` into `Matrix4x4` for transformation
- document and use `gp_Trsf` parameter in header

## Testing
- `cmake -S . -B build` *(fails: Could not find Qt6Config.cmake)*

------
https://chatgpt.com/codex/tasks/task_e_6878cadd8d048332ac1c12d8e4797041