### PR TITLE
Align toolpath display with raw material

### DIFF
--- a/gui/src/workspacecontroller.cpp
+++ b/gui/src/workspacecontroller.cpp
@@ -1055,7 +1055,7 @@ bool WorkspaceController::generateToolpaths()
         if (m_coordinateManager && m_coordinateManager->isInitialized()) {
             // Get work coordinate system transformation matrix
             const auto& workCS = m_coordinateManager->getWorkCoordinateSystem();
-            const auto& matrix = workCS.getFromGlobalMatrix(); // Transform from global to work coordinates
+            const auto& matrix = workCS.getToGlobalMatrix(); // Transform from work to global coordinates
             
             // Create OpenCASCADE transformation matrix from work coordinate system
             workCoordinateTransform.SetValues(


### PR DESCRIPTION
## Summary
- fix coordinate transform passed to pipeline so it converts work coordinates to global space
- apply the transformation to toolpaths when creating display objects

## Testing
- `cmake --preset vs2022-debug` *(fails: Visual Studio generator not found)*

------
https://chatgpt.com/codex/tasks/task_e_6878e36bc3c08332a702d13845b9c42f