### PR TITLE
Fix toolpath positioning using work coordinate system

### DIFF
--- a/core/toolpath/include/IntuiCAM/Toolpath/ToolpathGenerationPipeline.h
+++ b/core/toolpath/include/IntuiCAM/Toolpath/ToolpathGenerationPipeline.h
@@ -215,7 +215,7 @@ public:
     // Public helper methods for toolpath display 
     std::vector<Handle(AIS_InteractiveObject)> createToolpathDisplayObjects(
         const std::vector<std::unique_ptr<Toolpath>>& toolpaths,
-        const gp_Trsf& workpieceTransform = gp_Trsf());
+        const IntuiCAM::Geometry::WorkCoordinateSystem& workCS);
 
 private:
     // Generation state

--- a/core/toolpath/include/IntuiCAM/Toolpath/Types.h
+++ b/core/toolpath/include/IntuiCAM/Toolpath/Types.h
@@ -182,6 +182,18 @@ public:
     
     // Apply a 4x4 transform to every movement (e.g., part positioning in world space)
     void applyTransform(const Geometry::Matrix4x4& mat);
+
+    /**
+     * @brief Transform toolpath movements from lathe work coordinates to global
+     *        coordinates using a work coordinate system.
+     *
+     * Movements in generated toolpaths use a lathe-friendly convention where
+     * `x` stores the axial position (Z in machine coordinates) and `z` stores
+     * the radial position. This helper converts all stored points through the
+     * provided work coordinate system so the toolpath aligns with the current
+     * raw material position.
+     */
+    void applyWorkCoordinateSystem(const Geometry::WorkCoordinateSystem& wcs);
 };
 
 // Base class for machining operations

--- a/core/toolpath/src/ToolpathGenerationPipeline.cpp
+++ b/core/toolpath/src/ToolpathGenerationPipeline.cpp
@@ -1157,7 +1157,7 @@ std::vector<std::unique_ptr<Toolpath>> ToolpathGenerationPipeline::partingToolpa
 
 std::vector<Handle(AIS_InteractiveObject)> ToolpathGenerationPipeline::createToolpathDisplayObjects(
     const std::vector<std::unique_ptr<Toolpath>>& toolpaths,
-    const gp_Trsf& workpieceTransform) {
+    const IntuiCAM::Geometry::WorkCoordinateSystem& workCS) {
     
     std::vector<Handle(AIS_InteractiveObject)> displayObjects;
     
@@ -1234,7 +1234,10 @@ std::vector<Handle(AIS_InteractiveObject)> ToolpathGenerationPipeline::createToo
             for (const auto& movement : movements) {
                 newToolpath->addMovement(movement);
             }
-            
+
+            // Transform to global coordinates using the work coordinate system
+            newToolpath->applyWorkCoordinateSystem(workCS);
+
             sharedToolpath = newToolpath;
             
             // Create the ToolpathDisplayObject

--- a/core/toolpath/src/Types.cpp
+++ b/core/toolpath/src/Types.cpp
@@ -228,6 +228,18 @@ void Toolpath::applyTransform(const Geometry::Matrix4x4& mat) {
     }
 }
 
+void Toolpath::applyWorkCoordinateSystem(const Geometry::WorkCoordinateSystem& wcs) {
+    for (auto& movement : movements_) {
+        Geometry::Point2D lathePos(movement.position.z, movement.position.x);
+        Geometry::Point2D latheStart(movement.startPoint.z, movement.startPoint.x);
+        Geometry::Point2D latheEnd(movement.endPoint.z, movement.endPoint.x);
+
+        movement.position = wcs.latheToGlobal(lathePos);
+        movement.startPoint = wcs.latheToGlobal(latheStart);
+        movement.endPoint = wcs.latheToGlobal(latheEnd);
+    }
+}
+
 // Operation Implementation
 Operation::Operation(Type type, const std::string& name, std::shared_ptr<Tool> tool)
     : type_(type), name_(name), tool_(tool) {}


### PR DESCRIPTION
## Summary
- expose `applyWorkCoordinateSystem` on `Toolpath` to convert lathe moves
- use work coordinate system when building display toolpaths
- update pipeline helper to take a work coordinate system instead of a raw transform
- update workspace controller to pass the current work coordinate system

## Testing
- `cmake ..` *(fails: Could not find a package configuration file provided by "Qt6")*

------
https://chatgpt.com/codex/tasks/task_e_6878eb00a0fc8332b11003109d0cc068